### PR TITLE
Performance improvements

### DIFF
--- a/crypto_test.go
+++ b/crypto_test.go
@@ -90,3 +90,21 @@ func TestVerifyQuorumCert(t *testing.T) {
 		t.Errorf("Quorum cert failed to verify!")
 	}
 }
+
+func BenchmarkQuroumCertToBytes(b *testing.B) {
+	qc := CreateQuorumCert(testNode)
+	for _, r := range biggerRc.Replicas {
+		pc, _ := CreatePartialCert(r.ID, &pk, testNode)
+		qc.AddPartial(pc)
+	}
+	for n := 0; n < b.N; n++ {
+		qc.toBytes()
+	}
+}
+
+func BenchmarkPartialSigToBytes(b *testing.B) {
+	pc, _ := CreatePartialCert(0, &pk, testNode)
+	for n := 0; n < b.N; n++ {
+		pc.Sig.toBytes()
+	}
+}

--- a/gorumshotstuff/gorumshotstuff.go
+++ b/gorumshotstuff/gorumshotstuff.go
@@ -128,8 +128,8 @@ func (hs *GorumsHotStuff) startClient(connectTimeout time.Duration) error {
 	}
 
 	hs.qspec = &hotstuffQSpec{
-		SignatureVerifier: hs.Sigs,
-		ReplicaConfig:     hs.ReplicaConfig,
+		SignatureCache: hs.SigCache,
+		ReplicaConfig:  hs.ReplicaConfig,
 	}
 
 	hs.config, err = hs.manager.NewConfiguration(hs.manager.NodeIDs(), hs.qspec)

--- a/gorumshotstuff/gorumshotstuff.go
+++ b/gorumshotstuff/gorumshotstuff.go
@@ -128,7 +128,8 @@ func (hs *GorumsHotStuff) startClient(connectTimeout time.Duration) error {
 	}
 
 	hs.qspec = &hotstuffQSpec{
-		ReplicaConfig: hs.ReplicaConfig,
+		SignatureVerifier: hs.Sigs,
+		ReplicaConfig:     hs.ReplicaConfig,
 	}
 
 	hs.config, err = hs.manager.NewConfiguration(hs.manager.NodeIDs(), hs.qspec)

--- a/gorumshotstuff/qspec.go
+++ b/gorumshotstuff/qspec.go
@@ -8,6 +8,7 @@ import (
 )
 
 type hotstuffQSpec struct {
+	*hotstuff.SignatureVerifier
 	*hotstuff.ReplicaConfig
 	verified map[*proto.PartialCert]bool
 	jobs     chan struct {
@@ -34,7 +35,7 @@ func (qspec *hotstuffQSpec) ProposeQF(req *proto.HSNode, replies []*proto.Partia
 			qspec.wg.Add(1)
 			go func(pc *proto.PartialCert) {
 				cert := pc.FromProto()
-				ok := hotstuff.VerifyPartialCert(qspec.ReplicaConfig, cert)
+				ok := qspec.VerifySignature(cert.Sig, cert.NodeHash)
 				qspec.jobs <- struct {
 					pc *proto.PartialCert
 					ok bool

--- a/gorumshotstuff/qspec.go
+++ b/gorumshotstuff/qspec.go
@@ -8,7 +8,7 @@ import (
 )
 
 type hotstuffQSpec struct {
-	*hotstuff.SignatureVerifier
+	*hotstuff.SignatureCache
 	*hotstuff.ReplicaConfig
 	verified map[*proto.PartialCert]bool
 	jobs     chan struct {

--- a/hotstuff.go
+++ b/hotstuff.go
@@ -297,7 +297,7 @@ func (hs *HotStuff) OnReceiveProposal(node *Node) (*PartialCert, error) {
 	// queue node for update
 	hs.pendingUpdates <- node
 
-	pc, err := CreatePartialCert(hs.id, hs.privKey, node)
+	pc, err := hs.Sigs.CreatePartialCert(hs.id, hs.privKey, node)
 	if err != nil {
 		return nil, err
 	}

--- a/node_test.go
+++ b/node_test.go
@@ -48,3 +48,28 @@ func TestFuzzNodeHash(t *testing.T) {
 		}
 	}
 }
+
+func BenchmarkNodeHash(b *testing.B) {
+	pk1, _ := GeneratePrivateKey()
+	pk2, _ := GeneratePrivateKey()
+	pk3, _ := GeneratePrivateKey()
+
+	parent := &Node{Commands: []Command{"Test"}}
+
+	node := &Node{Commands: []Command{"Hello world"}, ParentHash: parent.Hash()}
+
+	node.Justify = CreateQuorumCert(parent)
+	pc1, _ := CreatePartialCert(1, pk1, parent)
+	node.Justify.AddPartial(pc1)
+	pc2, _ := CreatePartialCert(2, pk2, parent)
+	node.Justify.AddPartial(pc2)
+	pc3, _ := CreatePartialCert(3, pk3, parent)
+	node.Justify.AddPartial(pc3)
+
+	for n := 0; n < b.N; n++ {
+		b.StopTimer()
+		node.hash = nil
+		b.StartTimer()
+		node.Hash()
+	}
+}


### PR DESCRIPTION
This PR attempts to optimize the hashing of Nodes and introduces caching of partial signatures.

In particular, hashing of Nodes is now ~15% faster and allocates less memory:
```
Before:

BenchmarkNodeHash-8       332913              3257 ns/op            2048 B/op         26 allocs/op

After:

BenchmarkNodeHash-8       418737              2836 ns/op            1648 B/op         20 allocs/op
```

A much greater performance improvement is seen by caching partial signatures such that they only need to be verified once. For the leader replica, the verifications will happen in `ProposeQF`. This means that when the leader later calls `UpdateQCHigh`, all of the partial certificates will have cached results. For other replicas, the verification will happen in `UpdateQCHigh`, but a replica can skip the partial signature created by itself.

I need to do some more testing, but a quick throughput measurement shows about a 15% improvement in throughput (though some of this is probably due to the recent performance improvement in [gorums](https://github.com/relab/gorums/pull/62)).