### PR TITLE
Timeout clean up

### DIFF
--- a/cmd/hotstuffserver/main.go
+++ b/cmd/hotstuffserver/main.go
@@ -201,7 +201,7 @@ func newHotStuffServer(key *ecdsa.PrivateKey, conf *config, replicaConfig *hotst
 		finishedCmds: make(map[hotstuff.Command]chan struct{}),
 		lastExecTime: time.Now().UnixNano(),
 	}
-	srv.backend = gorumshotstuff.New(time.Minute, time.Duration(conf.ViewTimeout)*time.Millisecond)
+	srv.backend = gorumshotstuff.New(time.Minute)
 	srv.hs = hotstuff.New(conf.SelfID, key, replicaConfig, srv.backend, waitDuration, srv.onExec)
 	switch conf.PmType {
 	case "fixed":

--- a/gorumshotstuff/gorumshotstuff_test.go
+++ b/gorumshotstuff/gorumshotstuff_test.go
@@ -1,6 +1,7 @@
 package gorumshotstuff
 
 import (
+	"context"
 	"crypto/ecdsa"
 	"sync"
 	"testing"
@@ -30,10 +31,10 @@ func TestHotStuff(t *testing.T) {
 	out[4] = make(chan []hotstuff.Command, 4)
 
 	replicas := make(map[hotstuff.ReplicaID]*GorumsHotStuff)
-	replicas[2] = New(10*time.Second, time.Second)
-	replicas[1] = New(10*time.Second, time.Second)
-	replicas[3] = New(10*time.Second, time.Second)
-	replicas[4] = New(10*time.Second, time.Second)
+	replicas[2] = New(10 * time.Second)
+	replicas[1] = New(10 * time.Second)
+	replicas[3] = New(10 * time.Second)
+	replicas[4] = New(10 * time.Second)
 
 	hotstuff.New(1, keys[1], config, replicas[1], 50*time.Millisecond, func(b []hotstuff.Command) { out[1] <- b })
 	hotstuff.New(2, keys[2], config, replicas[2], 50*time.Millisecond, func(b []hotstuff.Command) { out[2] <- b })
@@ -66,7 +67,7 @@ func TestHotStuff(t *testing.T) {
 
 	for _, t := range test {
 		replicas[1].HotStuff.AddCommand(t)
-		replicas[1].HotStuff.Propose()
+		replicas[1].HotStuff.Propose(context.Background())
 	}
 
 	for id := range replicas {

--- a/hotstuff.go
+++ b/hotstuff.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"log"
 	"sync"
-	"time"
 
 	"github.com/relab/hotstuff/internal/logging"
 )
@@ -146,8 +145,7 @@ func (hs *HotStuff) GetQCHigh() *QuorumCert {
 }
 
 // New creates a new Hotstuff instance
-func New(id ReplicaID, privKey *ecdsa.PrivateKey, config *ReplicaConfig, backend Backend,
-	waitDuration time.Duration, exec func([]Command)) *HotStuff {
+func New(id ReplicaID, privKey *ecdsa.PrivateKey, config *ReplicaConfig, backend Backend, exec func([]Command)) *HotStuff {
 	logger.SetPrefix(fmt.Sprintf("hs(id %d): ", id))
 	genesis := &Block{
 		Committed: true,

--- a/hotstuff.toml
+++ b/hotstuff.toml
@@ -1,4 +1,4 @@
-pacemaker = "fixed"
+pacemaker = "round-robin"
 leader-id = 1
 view-change = 100
 leader-schedule = [1, 2, 3, 4]

--- a/hotstuff_test.go
+++ b/hotstuff_test.go
@@ -2,15 +2,18 @@ package hotstuff
 
 import (
 	"bytes"
+	"context"
 	"testing"
 	"time"
 )
 
 type stubBackend struct{}
 
-func (d *stubBackend) Init(hs *HotStuff)                                {}
-func (d *stubBackend) Start() error                                     { return nil }
-func (d *stubBackend) DoPropose(block *Block) (*QuorumCert, error)      { return nil, nil }
+func (d *stubBackend) Init(hs *HotStuff) {}
+func (d *stubBackend) Start() error      { return nil }
+func (d *stubBackend) DoPropose(ctx context.Context, block *Block) (*QuorumCert, error) {
+	return nil, nil
+}
 func (d *stubBackend) DoNewView(leader ReplicaID, qc *QuorumCert) error { return nil }
 func (d *stubBackend) Close()                                           {}
 

--- a/hotstuff_test.go
+++ b/hotstuff_test.go
@@ -65,7 +65,7 @@ func (d *stubBackend) Close() {}
 
 func TestUpdateQCHigh(t *testing.T) {
 	key, _ := GeneratePrivateKey()
-	hs := New(1, key, NewConfig(), &stubBackend{}, 10*time.Millisecond, nil)
+	hs := New(1, key, NewConfig(), &stubBackend{}, nil)
 	block1 := CreateLeaf(hs.genesis, []Command{Command("command1")}, hs.qcHigh, hs.genesis.Height+1)
 	hs.blocks.Put(block1)
 	qc1 := CreateQuorumCert(block1)
@@ -95,7 +95,7 @@ func TestUpdateQCHigh(t *testing.T) {
 func TestUpdate(t *testing.T) {
 	exec := make(chan []Command, 1)
 	key, _ := GeneratePrivateKey()
-	hs := New(1, key, NewConfig(), &stubBackend{}, 10*time.Millisecond, func(b []Command) { exec <- b })
+	hs := New(1, key, NewConfig(), &stubBackend{}, func(b []Command) { exec <- b })
 	hs.QuorumSize = 0 // this accepts all QCs
 
 	n1 := CreateLeaf(hs.genesis, []Command{Command("n1")}, hs.qcHigh, hs.genesis.Height+1)
@@ -148,7 +148,7 @@ func TestUpdate(t *testing.T) {
 
 func TestOnReciveProposal(t *testing.T) {
 	key, _ := GeneratePrivateKey()
-	hs := New(1, key, NewConfig(), &stubBackend{}, 10*time.Millisecond, nil)
+	hs := New(1, key, NewConfig(), &stubBackend{}, nil)
 	block1 := CreateLeaf(hs.genesis, []Command{Command("command1")}, hs.qcHigh, hs.genesis.Height+1)
 	qc := CreateQuorumCert(block1)
 
@@ -184,7 +184,7 @@ func TestOnReciveProposal(t *testing.T) {
 
 func TestExpectBlockFor(t *testing.T) {
 	key, _ := GeneratePrivateKey()
-	hs := New(1, key, NewConfig(), &stubBackend{}, time.Second, nil)
+	hs := New(1, key, NewConfig(), &stubBackend{}, nil)
 	block := CreateLeaf(hs.genesis, []Command{Command("test")}, hs.qcHigh, 1)
 	qc := CreateQuorumCert(block)
 

--- a/hotstuff_test.go
+++ b/hotstuff_test.go
@@ -14,8 +14,10 @@ func (d *stubBackend) Start() error      { return nil }
 func (d *stubBackend) DoPropose(ctx context.Context, block *Block) (*QuorumCert, error) {
 	return nil, nil
 }
-func (d *stubBackend) DoNewView(leader ReplicaID, qc *QuorumCert) error { return nil }
-func (d *stubBackend) Close()                                           {}
+func (d *stubBackend) DoNewView(ctx context.Context, leader ReplicaID, qc *QuorumCert) error {
+	return nil
+}
+func (d *stubBackend) Close() {}
 
 /* func TestSafeNode(t *testing.T) {
 	key, _ := GeneratePrivateKey()

--- a/pacemaker/pacemaker.go
+++ b/pacemaker/pacemaker.go
@@ -38,8 +38,9 @@ func NewFixedLeader(hs *hotstuff.HotStuff, leaderID hotstuff.ReplicaID) *FixedLe
 // Run runs the pacemaker which will beat when the previous QC is completed
 func (p FixedLeader) Run(ctx context.Context) {
 	notify := p.GetNotifier()
+	dummyCtx := context.Background()
 	if p.GetID() == p.leader {
-		go p.Propose()
+		go p.Propose(dummyCtx)
 	}
 	var n hotstuff.Notification
 	var ok bool
@@ -55,7 +56,7 @@ func (p FixedLeader) Run(ctx context.Context) {
 		switch n.Event {
 		case hotstuff.QCFinish:
 			if p.GetID() == p.leader {
-				go p.Propose()
+				go p.Propose(dummyCtx)
 			}
 		}
 	}
@@ -69,8 +70,10 @@ type RoundRobin struct {
 	schedule   []hotstuff.ReplicaID
 	timeout    time.Duration
 
-	resetTimer  chan struct{} // sending on this channel will reset the timer
-	stopTimeout func()        // stops the new-view interrupts
+	resetTimer           chan struct{}   // sending on this channel will reset the timer
+	stopTimeout          func()          // stops the new-view interrupts
+	timeoutContext       context.Context // timeoutContext is passed down to the RPC's. A new context is created for every transmission.
+	timeoutContextCancle func()          // timeoutContext times out after the timeout time in the pacemaker timeout variable.
 }
 
 // NewRoundRobin returns a new round robin pacemaker
@@ -94,9 +97,16 @@ func (p *RoundRobin) getLeader(vHeight int) hotstuff.ReplicaID {
 func (p *RoundRobin) Run(ctx context.Context) {
 	notify := p.GetNotifier()
 
+	// set up new-view interrupt
+	p.timeoutContext, p.timeoutContextCancle = context.WithCancel(ctx)
+	stopContext, cancel := context.WithCancel(ctx)
+	p.stopTimeout = cancel
+	go p.startNewViewTimeout(stopContext)
+	defer p.stopTimeout()
+
 	// initial beat
 	if p.getLeader(1) == p.GetID() {
-		go p.Propose()
+		go p.Propose(p.timeoutContext)
 	}
 
 	// get initial notification
@@ -105,19 +115,13 @@ func (p *RoundRobin) Run(ctx context.Context) {
 	// make sure that we only beat once per view, and don't beat if bLeaf.Height < vHeight
 	// as that would cause a panic
 	lastBeat := 1
-	beat := func() {
+	beat := func(ctx context.Context) {
 		if p.getLeader(p.GetHeight()+1) == p.GetID() && lastBeat < p.GetHeight()+1 &&
 			p.GetHeight()+1 > p.GetVotedHeight() {
 			lastBeat = p.GetHeight() + 1
-			go p.Propose()
+			go p.Propose(ctx)
 		}
 	}
-
-	// set up new-view interrupt
-	stopContext, cancel := context.WithCancel(context.Background())
-	p.stopTimeout = cancel
-	go p.startNewViewTimeout(stopContext)
-	defer p.stopTimeout()
 
 	// handle events from hotstuff
 	for {
@@ -125,14 +129,17 @@ func (p *RoundRobin) Run(ctx context.Context) {
 		case hotstuff.ReceiveProposal:
 			p.resetTimer <- struct{}{}
 		case hotstuff.QCFinish:
+			p.timeoutContext, p.timeoutContextCancle = context.WithCancel(ctx)
 			if p.GetID() != p.getLeader(p.GetHeight()+1) {
 				// was leader for previous view, but not the leader for next view
 				// do leader change
-				go p.SendNewView(p.getLeader(p.GetHeight() + 1))
+				go p.SendNewView(p.timeoutContext, p.getLeader(p.GetHeight()+1))
 			}
-			beat()
+			beat(p.timeoutContext)
 		case hotstuff.ReceiveNewView:
-			beat()
+			p.resetTimer <- struct{}{} // the same timeout mechanisme is used for proposal and new-view messages.
+			p.timeoutContext, p.timeoutContextCancle = context.WithCancel(ctx)
+			beat(p.timeoutContext)
 		}
 
 		var ok bool
@@ -153,13 +160,18 @@ func (p *RoundRobin) startNewViewTimeout(stopContext context.Context) {
 	for {
 		select {
 		case <-p.resetTimer:
+		case <-p.timeoutContext.Done():
+			p.timeoutContextCancle()
 		case <-stopContext.Done():
+			p.timeoutContextCancle()
 			return
 		case <-time.After(p.timeout):
+			p.timeoutContextCancle()
+			p.timeoutContext, p.timeoutContextCancle = context.WithCancel(context.Background()) // Would maybe be better to pass in the run context here, but whatever for now.
 			// add a dummy block to the tree representing this round which failed
 			logger.Println("NewViewTimeout triggered")
 			p.SetLeaf(hotstuff.CreateLeaf(p.GetLeaf(), nil, nil, p.GetHeight()+1))
-			p.SendNewView(p.getLeader(p.GetHeight() + 1))
+			p.SendNewView(p.timeoutContext, p.getLeader(p.GetHeight()+1))
 		}
 	}
 }

--- a/pacemaker/pacemaker.go
+++ b/pacemaker/pacemaker.go
@@ -160,7 +160,6 @@ func (p *RoundRobin) startNewViewTimeout(stopContext context.Context) {
 	for {
 		select {
 		case <-p.resetTimer:
-		case <-p.timeoutContext.Done():
 			p.timeoutContextCancle()
 		case <-stopContext.Done():
 			p.timeoutContextCancle()


### PR DESCRIPTION
Have merged the RPC timeout and new-view timeout together. Have also changed how ExpectBlockFor works. ExpectBlockFor now waits for the replica to receive exactly one new proposal if the expected block is not present. Previously ExpectBlockFor timed out after a given time.   