### PR TITLE
controller:  write host assignments to a file

### DIFF
--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -101,6 +101,7 @@ func runController() {
 		NumReplicas: viper.GetInt("replicas"),
 		NumClients:  viper.GetInt("clients"),
 		Duration:    viper.GetDuration("duration"),
+		Output:      outputDir,
 		ReplicaOpts: &orchestrationpb.ReplicaOpts{
 			UseTLS:            true,
 			BatchSize:         viper.GetUint32("batch-size"),


### PR DESCRIPTION
This PR makes the controller write the mapping of hosts to clients and replicas to a JSON file in the output directory.

Fixes #53