### PR TITLE
consensus: add a SubConfig method to Configuration

### DIFF
--- a/consensus/modules.go
+++ b/consensus/modules.go
@@ -350,6 +350,8 @@ type Configuration interface {
 	Timeout(msg TimeoutMsg)
 	// Fetch requests a block from all the replicas in the configuration.
 	Fetch(ctx context.Context, hash Hash) (block *Block, ok bool)
+	// SubConfig returns a subconfiguration containing the replicas specified in the ids slice.
+	SubConfig(ids []hotstuff.ID) (sub Configuration, err error)
 }
 
 //go:generate mockgen -destination=../internal/mocks/consensus_mock.go -package=mocks . Consensus

--- a/internal/mocks/configuration_mock.go
+++ b/internal/mocks/configuration_mock.go
@@ -120,6 +120,21 @@ func (mr *MockConfigurationMockRecorder) Replicas() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Replicas", reflect.TypeOf((*MockConfiguration)(nil).Replicas))
 }
 
+// SubConfig mocks base method.
+func (m *MockConfiguration) SubConfig(arg0 []hotstuff.ID) (consensus.Configuration, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SubConfig", arg0)
+	ret0, _ := ret[0].(consensus.Configuration)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// SubConfig indicates an expected call of SubConfig.
+func (mr *MockConfigurationMockRecorder) SubConfig(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SubConfig", reflect.TypeOf((*MockConfiguration)(nil).SubConfig), arg0)
+}
+
 // Timeout mocks base method.
 func (m *MockConfiguration) Timeout(arg0 consensus.TimeoutMsg) {
 	m.ctrl.T.Helper()

--- a/twins/network.go
+++ b/twins/network.go
@@ -182,8 +182,9 @@ func (n *network) shouldDrop(sender, receiver uint32, message interface{}) bool 
 }
 
 type configuration struct {
-	node    *node
-	network *network
+	node      *node
+	network   *network
+	subConfig consensus.IDSet
 }
 
 func (c *configuration) broadcastMessage(message interface{}) {
@@ -191,8 +192,9 @@ func (c *configuration) broadcastMessage(message interface{}) {
 		if id == c.node.id.ReplicaID {
 			// do not send message to self or twin
 			continue
+		} else if c.subConfig == nil || c.subConfig.Contains(id) {
+			c.sendMessage(id, message)
 		}
-		c.sendMessage(id, message)
 	}
 }
 
@@ -238,6 +240,19 @@ func (c *configuration) Replica(id hotstuff.ID) (r consensus.Replica, ok bool) {
 		}, true
 	}
 	return nil, false
+}
+
+// SubConfig returns a subconfiguration containing the replicas specified in the ids slice.
+func (c *configuration) SubConfig(ids []hotstuff.ID) (sub consensus.Configuration, err error) {
+	subConfig := consensus.NewIDSet()
+	for _, id := range ids {
+		subConfig.Add(id)
+	}
+	return &configuration{
+		node:      c.node,
+		network:   c.network,
+		subConfig: subConfig,
+	}, nil
 }
 
 // Len returns the number of replicas in the configuration.


### PR DESCRIPTION
This makes it possible to create subconfigurations of the main configuration.

I used this to make broadcasting optional in the synchronizer, but have since removed this code. However, I think it could be a useful feature to have anyway.