### PR TITLE
modules/registry: use generics to constrain types

### DIFF
--- a/internal/orchestration/worker.go
+++ b/internal/orchestration/worker.go
@@ -163,25 +163,24 @@ func (w *Worker) createReplica(opts *orchestrationpb.ReplicaOpts) (*replica.Repl
 	// prepare modules
 	builder := consensus.NewBuilder(hotstuff.ID(opts.GetID()), privKey)
 
-	var consensusRules consensus.Rules
-	if !modules.GetModule(opts.GetConsensus(), &consensusRules) {
+	consensusRules, ok := modules.GetModule[consensus.Rules](opts.GetConsensus())
+	if !ok {
 		return nil, fmt.Errorf("invalid consensus name: '%s'", opts.GetConsensus())
 	}
 
-	var byz byzantine.Byzantine
-	if modules.GetModule(opts.GetByzantineStrategy(), &byz) {
+	if byz, ok := modules.GetModule[byzantine.Byzantine](opts.GetByzantineStrategy()); ok {
 		consensusRules = byz.Wrap(consensusRules)
 	} else if opts.GetByzantineStrategy() != "" {
 		return nil, fmt.Errorf("invalid byzantine strategy: '%s'", opts.GetByzantineStrategy())
 	}
 
-	var cryptoImpl consensus.CryptoImpl
-	if !modules.GetModule(opts.GetCrypto(), &cryptoImpl) {
+	cryptoImpl, ok := modules.GetModule[consensus.CryptoImpl](opts.GetCrypto())
+	if !ok {
 		return nil, fmt.Errorf("invalid crypto name: '%s'", opts.GetCrypto())
 	}
 
-	var leaderRotation consensus.LeaderRotation
-	if !modules.GetModule(opts.GetLeaderRotation(), &leaderRotation) {
+	leaderRotation, ok := modules.GetModule[consensus.LeaderRotation](opts.GetLeaderRotation())
+	if !ok {
 		return nil, fmt.Errorf("invalid leader-rotation algorithm: '%s'", opts.GetLeaderRotation())
 	}
 

--- a/internal/orchestration/worker.go
+++ b/internal/orchestration/worker.go
@@ -168,10 +168,12 @@ func (w *Worker) createReplica(opts *orchestrationpb.ReplicaOpts) (*replica.Repl
 		return nil, fmt.Errorf("invalid consensus name: '%s'", opts.GetConsensus())
 	}
 
-	if byz, ok := modules.GetModule[byzantine.Byzantine](opts.GetByzantineStrategy()); ok {
-		consensusRules = byz.Wrap(consensusRules)
-	} else if opts.GetByzantineStrategy() != "" {
-		return nil, fmt.Errorf("invalid byzantine strategy: '%s'", opts.GetByzantineStrategy())
+	if opts.GetByzantineStrategy() != "" {
+		if byz, ok := modules.GetModule[byzantine.Byzantine](opts.GetByzantineStrategy()); ok {
+			consensusRules = byz.Wrap(consensusRules)
+		} else {
+			return nil, fmt.Errorf("invalid byzantine strategy: '%s'", opts.GetByzantineStrategy())
+		}
 	}
 
 	cryptoImpl, ok := modules.GetModule[consensus.CryptoImpl](opts.GetCrypto())

--- a/modules/registry.go
+++ b/modules/registry.go
@@ -12,18 +12,11 @@ var (
 	byName      = make(map[string]interface{})
 )
 
-// RegisterModule registers a module implementation with the specified name.
-// constructor must be a function returning the interface of the module.
+// RegisterModule registers a constructor for a module implementation with the specified name.
 // For example:
 //  RegisterModule("chainedhotstuff", func() consensus.Rules { return chainedhotstuff.New() })
-func RegisterModule(name string, constructor interface{}) {
-	ctorType := reflect.TypeOf(constructor)
-
-	if ctorType.Kind() != reflect.Func && ctorType.NumOut() != 1 && ctorType.Out(0).Kind() != reflect.Interface {
-		panic("invalid argument: constructor must be a function returning an interface")
-	}
-
-	ifaceType := ctorType.Out(0)
+func RegisterModule[T any](name string, constructor func() T) {
+	moduleType := reflect.TypeOf(constructor).Out(0)
 
 	registryMut.Lock()
 	defer registryMut.Unlock()
@@ -33,29 +26,22 @@ func RegisterModule(name string, constructor interface{}) {
 	}
 	byName[name] = constructor
 
-	moduleRegistry, ok := byInterface[ifaceType]
+	moduleRegistry, ok := byInterface[moduleType]
 	if !ok {
 		moduleRegistry = make(map[string]interface{})
-		byInterface[ifaceType] = moduleRegistry
+		byInterface[moduleType] = moduleRegistry
 	}
 
 	moduleRegistry[name] = constructor
 }
 
-// GetModule retrieves a new instance of the module with the specified name.
-// out must be a non-nil pointer to a variable with the interface type of the module.
+// GetModule constructs a new instance of the module with the specified name.
 // GetModule returns true if the module is found, false otherwise.
 // For example:
 //  var rules consensus.Rules
 //  GetModule("chainedhotstuff", &rules)
-func GetModule(name string, out interface{}) bool {
-	outType := reflect.TypeOf(out)
-
-	if outType.Kind() != reflect.Ptr {
-		panic("invalid argument: out must be a non-nil pointer to an interface variable")
-	}
-
-	targetType := outType.Elem()
+func GetModule[T any](name string, out *T) bool {
+	targetType := reflect.TypeOf(out).Elem()
 
 	registryMut.Lock()
 	defer registryMut.Unlock()
@@ -75,7 +61,7 @@ func GetModule(name string, out interface{}) bool {
 }
 
 // GetModuleUntyped returns a new instance of the named module, if it exists.
-func GetModuleUntyped(name string) (v interface{}, ok bool) {
+func GetModuleUntyped(name string) (m any, ok bool) {
 	registryMut.Lock()
 	defer registryMut.Unlock()
 
@@ -84,9 +70,9 @@ func GetModuleUntyped(name string) (v interface{}, ok bool) {
 		return nil, false
 	}
 
-	reflect.ValueOf(&v).Elem().Set(reflect.ValueOf(ctor).Call([]reflect.Value{})[0])
+	reflect.ValueOf(&m).Elem().Set(reflect.ValueOf(ctor).Call([]reflect.Value{})[0])
 
-	return v, ok
+	return m, ok
 }
 
 // ListModules returns a map of interface names to module names.

--- a/modules/registry_test.go
+++ b/modules/registry_test.go
@@ -11,8 +11,8 @@ func TestModuleRegistry(t *testing.T) {
 		return module{}
 	})
 
-	var frobulator moduleIface
-	if !modules.GetModule("frobulator", &frobulator) {
+	frobulator, ok := modules.GetModule[moduleIface]("frobulator")
+	if !ok {
 		t.Fatal("module was not found")
 	}
 

--- a/twins/network.go
+++ b/twins/network.go
@@ -88,8 +88,8 @@ func (n *network) createNodes(nodes []NodeID, scenario Scenario, consensusName s
 			id: nodeID,
 		}
 		builder := consensus.NewBuilder(nodeID.ReplicaID, pk)
-		var consensusModule consensus.Rules
-		if !modules.GetModule(consensusName, &consensusModule) {
+		consensusModule, ok := modules.GetModule[consensus.Rules](consensusName)
+		if !ok {
 			return fmt.Errorf("unknown consensus module: '%s'", consensusName)
 		}
 		builder.Register(


### PR DESCRIPTION
We can use generics to constrain the types of module constructors and pointers at compile time to avoid having to check them at runtime.