### PR TITLE
Fix go version

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ It also provides a tool for deploying and running experiments on multiple server
 
 ## Build Dependencies
 
-- [Go](https://go.dev) (at least version 1.16)
+- [Go](https://go.dev) (at least version 1.18)
 
 If you modify any of the protobuf files, you will need the following to compile them:
 

--- a/docs/experimentation.md
+++ b/docs/experimentation.md
@@ -115,7 +115,7 @@ func init() {
 ## Running experiments locally
 
 First, compile the cli by running `make` from the project's root directory. If you get any errors, make sure that you
-have go version 1.16 or later, as well as a protobuf compiler installed. You might also need to run `make tools` to
+have go version 1.18 or later, as well as a protobuf compiler installed. You might also need to run `make tools` to
 install some additional tools. The next sections will assume that you have done this, and that you are running the cli
 from the project's root directory.
 


### PR DESCRIPTION
Hey there! Started playing around with your repo today and noticed it requires go 1.18 while the docs mention go 1.16. Here's a quick fix.