### PR TITLE
Removed leafBlock from synchronizer

### DIFF
--- a/consensus/byzantine/byzantine.go
+++ b/consensus/byzantine/byzantine.go
@@ -62,7 +62,11 @@ func (f *fork) InitModule(mods *modules.Core) {
 }
 
 func (f *fork) ProposeRule(cert hotstuff.SyncInfo, cmd hotstuff.Command) (proposal hotstuff.ProposeMsg, ok bool) {
-	parent, ok := f.blockChain.Get(f.synchronizer.LeafBlock().Parent())
+	block, ok := f.blockChain.Get(f.synchronizer.HighQC().BlockHash())
+	if !ok {
+		return proposal, false
+	}
+	parent, ok := f.blockChain.Get(block.Parent())
 	if !ok {
 		return proposal, false
 	}

--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -139,7 +139,7 @@ func (cs *consensusBase) Propose(cert hotstuff.SyncInfo) {
 		proposal = hotstuff.ProposeMsg{
 			ID: cs.opts.ID(),
 			Block: hotstuff.NewBlock(
-				cs.synchronizer.LeafBlock().Hash(),
+				qc.BlockHash(),
 				qc,
 				cmd,
 				cs.synchronizer.View(),

--- a/consensus/votingmachine.go
+++ b/consensus/votingmachine.go
@@ -75,7 +75,7 @@ func (vm *VotingMachine) OnVote(vote hotstuff.VoteMsg) {
 		}
 	}
 
-	if block.View() <= vm.synchronizer.LeafBlock().View() {
+	if block.View() <= vm.synchronizer.HighQC().View() {
 		// too old
 		return
 	}
@@ -101,7 +101,7 @@ func (vm *VotingMachine) verifyCert(cert hotstuff.PartialCert, block *hotstuff.B
 		// delete any pending QCs with lower height than bLeaf
 		for k := range vm.verifiedVotes {
 			if block, ok := vm.blockChain.LocalGet(k); ok {
-				if block.View() <= vm.synchronizer.LeafBlock().View() {
+				if block.View() <= vm.synchronizer.HighQC().View() {
 					delete(vm.verifiedVotes, k)
 				}
 			} else {

--- a/modules/modules.go
+++ b/modules/modules.go
@@ -160,8 +160,6 @@ type Synchronizer interface {
 	ViewContext() context.Context
 	// HighQC returns the highest known QC.
 	HighQC() hotstuff.QuorumCert
-	// LeafBlock returns the current leaf block.
-	LeafBlock() *hotstuff.Block
 	// Start starts the synchronizer with the given context.
 	Start(context.Context)
 }


### PR DESCRIPTION
I wanted to study the semantics of the synchronizer, and I found that the `leafBlock` is always the block from the `highQC`.
Therefore, in the current implementation, we could omit the `leafBlock`.