### PR TITLE
Pipelining

### DIFF
--- a/consensus/chainedhotstuff/chainedhotstuff.go
+++ b/consensus/chainedhotstuff/chainedhotstuff.go
@@ -74,7 +74,7 @@ func (hs *ChainedHotStuff) CommitRule(block *hotstuff.Block) *hotstuff.Block {
 	}
 
 	// pipelined rule
-	// find all confirmed blocks
+	// check if all blocks between b1 and b3 are confirmed
 	qcs := make(map[hotstuff.Hash]bool, block.View()-block3.View())
 	for loopblock := block; loopblock.View() > block1.View(); {
 		qcs[loopblock.QuorumCert().BlockHash()] = true

--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -240,7 +240,7 @@ func (cs *consensusBase) OnPropose(proposal hotstuff.ProposeMsg) { //nolint:gocy
 		return
 	}
 
-	leaderID := cs.leaderRotation.GetLeader(cs.lastVote + 1)
+	leaderID := cs.leaderRotation.GetLeader(block.View() + cs.synchronizer.PipelinedViews())
 	if leaderID == cs.opts.ID() {
 		cs.eventLoop.AddEvent(hotstuff.VoteMsg{ID: cs.opts.ID(), PartialCert: pc})
 		return

--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -215,7 +215,7 @@ func (cs *consensusBase) OnPropose(proposal hotstuff.ProposeMsg) { //nolint:gocy
 			cs.commit(b)
 		}
 		if !didAdvanceView {
-			cs.synchronizer.AdvanceView(hotstuff.NewSyncInfo().WithQC(block.QuorumCert()))
+			cs.synchronizer.AdvanceView(hotstuff.NewSyncInfo().WithQC(block.QuorumCert()).WithBlock(block))
 		}
 	}()
 

--- a/consensus/votingmachine.go
+++ b/consensus/votingmachine.go
@@ -75,7 +75,7 @@ func (vm *VotingMachine) OnVote(vote hotstuff.VoteMsg) {
 		}
 	}
 
-	if block.View() <= vm.synchronizer.LeafBlock().View() {
+	if block.View() <= vm.synchronizer.HighQC().View() {
 		// too old
 		return
 	}
@@ -101,7 +101,7 @@ func (vm *VotingMachine) verifyCert(cert hotstuff.PartialCert, block *hotstuff.B
 		// delete any pending QCs with lower height than bLeaf
 		for k := range vm.verifiedVotes {
 			if block, ok := vm.blockChain.LocalGet(k); ok {
-				if block.View() <= vm.synchronizer.LeafBlock().View() {
+				if block.View() <= vm.synchronizer.HighQC().View() {
 					delete(vm.verifiedVotes, k)
 				}
 			} else {

--- a/modules/modules.go
+++ b/modules/modules.go
@@ -162,6 +162,8 @@ type Synchronizer interface {
 	HighQC() hotstuff.QuorumCert
 	// LeafBlock returns the current leaf block.
 	LeafBlock() *hotstuff.Block
+	// PipelinedViews returns the number of concurrently executed views.
+	PipelinedViews() hotstuff.View
 	// Start starts the synchronizer with the given context.
 	Start(context.Context)
 }

--- a/synchronizer/synchronizer.go
+++ b/synchronizer/synchronizer.go
@@ -349,20 +349,9 @@ func (s *Synchronizer) AdvanceView(syncInfo hotstuff.SyncInfo) {
 // This method is meant to be used instead of the exported UpdateHighQC internally
 // in this package when the qc has already been verified.
 func (s *Synchronizer) updateHighQC(qc hotstuff.QuorumCert) {
-	newBlock, ok := s.blockChain.Get(qc.BlockHash())
-	if !ok {
-		s.logger.Info("updateHighQC: Could not find block referenced by new QC!")
-		return
-	}
 
-	oldBlock, ok := s.blockChain.Get(s.highQC.BlockHash())
-	if !ok {
-		s.logger.Panic("Block from the old highQC missing from chain")
-	}
-
-	if newBlock.View() > oldBlock.View() {
+	if qc.View() > s.highQC.View() {
 		s.highQC = qc
-		s.leafBlock = newBlock
 		s.logger.Debug("HighQC updated")
 	}
 }

--- a/synchronizer/synchronizer.go
+++ b/synchronizer/synchronizer.go
@@ -385,15 +385,14 @@ func (s *Synchronizer) updateHighQC(qc hotstuff.QuorumCert) {
 
 		// I believe the following can be removed, if leafBlock is updated elsewhere.
 		// However, placed here now for backwards compatibility
-		if s.leafBlock.View() < s.highQC.View() {
-			highQCBlock, ok := s.blockChain.Get(s.highQC.BlockHash())
-			if !ok {
-				s.logger.Info("updateHighQC: Could not find block referenced by new QC!")
-				return
-			}
-			if s.blockChain.Extends(s.leafBlock, highQCBlock) {
-				s.leafBlock = highQCBlock
-			}
+		highQCBlock, ok := s.blockChain.Get(s.highQC.BlockHash())
+		if !ok {
+			s.logger.Info("updateHighQC: Could not find block referenced by new QC!")
+			return
+		}
+
+		if s.leafBlock.View() < s.highQC.View() || !s.blockChain.Extends(s.leafBlock, highQCBlock) {
+			s.leafBlock = highQCBlock
 		}
 	}
 }

--- a/synchronizer/synchronizer.go
+++ b/synchronizer/synchronizer.go
@@ -353,6 +353,18 @@ func (s *Synchronizer) updateHighQC(qc hotstuff.QuorumCert) {
 	if qc.View() > s.highQC.View() {
 		s.highQC = qc
 		s.logger.Debug("HighQC updated")
+
+		// I believe the following can be removed, if leafBlock is updated elsewhere.
+		// However, placed here now for backwards compatibility
+		highQCBlock, ok := s.blockChain.Get(s.highQC.BlockHash())
+		if !ok {
+			s.logger.Info("updateHighQC: Could not find block referenced by new QC!")
+			return
+		}
+
+		if s.leafBlock.View() < s.highQC.View() || !s.blockChain.Extends(s.leafBlock, highQCBlock) {
+			s.leafBlock = highQCBlock
+		}
 	}
 }
 

--- a/types.go
+++ b/types.go
@@ -172,10 +172,12 @@ func (pc PartialCert) ToBytes() []byte {
 // Generally, if highQC.View > highTC.View, there is no need to include highTC in the SyncInfo.
 // However, if highQC.View < highTC.View, we should still include highQC.
 // This can also hold an AggregateQC for Fast-Hotstuff.
+// This can also hola a block.
 type SyncInfo struct {
 	qc    *QuorumCert
 	tc    *TimeoutCert
 	aggQC *AggregateQC
+	block *Block
 }
 
 // NewSyncInfo returns a new SyncInfo struct.
@@ -194,6 +196,12 @@ func (si SyncInfo) WithQC(qc QuorumCert) SyncInfo {
 func (si SyncInfo) WithTC(tc TimeoutCert) SyncInfo {
 	si.tc = new(TimeoutCert)
 	*si.tc = tc
+	return si
+}
+
+// WithBlock returns a copy of the SyncInfo struct with the given block.
+func (si SyncInfo) WithBlock(b *Block) SyncInfo {
+	si.block = b
 	return si
 }
 
@@ -228,6 +236,14 @@ func (si SyncInfo) AggQC() (_ AggregateQC, _ bool) {
 	return
 }
 
+// Block returns the block, if present.
+func (si SyncInfo) Block() (_ *Block, _ bool) {
+	if si.block != nil {
+		return si.block, true
+	}
+	return
+}
+
 func (si SyncInfo) String() string {
 	var sb strings.Builder
 	sb.WriteString("{ ")
@@ -239,6 +255,9 @@ func (si SyncInfo) String() string {
 	}
 	if si.aggQC != nil {
 		fmt.Fprintf(&sb, "%s ", si.aggQC)
+	}
+	if si.block != nil {
+		fmt.Fprintf(&sb, "%s ", si.block)
 	}
 	sb.WriteRune('}')
 	return sb.String()

--- a/types.go
+++ b/types.go
@@ -174,10 +174,11 @@ func (pc PartialCert) ToBytes() []byte {
 // This can also hold an AggregateQC for Fast-Hotstuff.
 // This can also hola a block.
 type SyncInfo struct {
-	qc    *QuorumCert
-	tc    *TimeoutCert
-	aggQC *AggregateQC
-	block *Block
+	qc         *QuorumCert
+	tc         *TimeoutCert
+	aggQC      *AggregateQC
+	block      *Block
+	timoutView View
 }
 
 // NewSyncInfo returns a new SyncInfo struct.
@@ -202,6 +203,12 @@ func (si SyncInfo) WithTC(tc TimeoutCert) SyncInfo {
 // WithBlock returns a copy of the SyncInfo struct with the given block.
 func (si SyncInfo) WithBlock(b *Block) SyncInfo {
 	si.block = b
+	return si
+}
+
+// WithTimeoutView returns a copy of the SyncInfo struct with a view marked as local timeout.
+func (si SyncInfo) WithTimeoutView(tv View) SyncInfo {
+	si.timoutView = tv
 	return si
 }
 
@@ -244,6 +251,14 @@ func (si SyncInfo) Block() (_ *Block, _ bool) {
 	return
 }
 
+// TimeoutView returns the timeout view, if present.
+func (si SyncInfo) TimeoutView() (_ View, _ bool) {
+	if si.timoutView != 0 {
+		return si.timoutView, true
+	}
+	return
+}
+
 func (si SyncInfo) String() string {
 	var sb strings.Builder
 	sb.WriteString("{ ")
@@ -258,6 +273,9 @@ func (si SyncInfo) String() string {
 	}
 	if si.block != nil {
 		fmt.Fprintf(&sb, "%s ", si.block)
+	}
+	if si.timoutView != 0 {
+		fmt.Fprintf(&sb, "timeoutView: %d ", si.timoutView)
 	}
 	sb.WriteRune('}')
 	return sb.String()


### PR DESCRIPTION
This implements pipelining for chained hotstuff.
Pipelined blocks still form a single chain, but need not include the certificate for their direct parent.

Commit rule is updated to commit requests if there is a depth 3 confirmation chain and all intermediate blocks are confirmed as well.