### PR TITLE
Replace go.uber.org/multierr with stdlib/errors.Join

### DIFF
--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -10,7 +10,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.20]
+        go-version: ['1.20']
         platform: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.platform }}
     steps:

--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -28,8 +28,8 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
-      - name: Set up Go
-        uses: actions/setup-go@v3
+      - name: Setup Go environment
+        uses: actions/setup-go@v4
         with:
           go-version: ${{ matrix.go-version }}
 

--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -10,7 +10,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.18]
+        go-version: [1.20]
         platform: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.platform }}
     steps:

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -16,11 +16,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-go@v3
-        with:
-          go-version: 1.20
-      - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3
+      - name: Setup Go environment
+        uses: actions/setup-go@v4
+      - name: Run golangci-lint
+        uses: golangci/golangci-lint-action@v3.4.0
         with:
           version: latest
           args: --timeout 5m

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.18
+          go-version: 1.20
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/relab/hotstuff
 
-go 1.18
+go 1.20
 
 require (
 	github.com/felixge/fgprof v0.9.2
@@ -16,7 +16,6 @@ require (
 	github.com/spf13/cobra v1.4.0
 	github.com/spf13/viper v1.11.0
 	go-hep.org/x/hep v0.31.1
-	go.uber.org/multierr v1.8.0
 	go.uber.org/zap v1.21.0
 	golang.org/x/exp v0.0.0-20220613132600-b0d781184e0d
 	golang.org/x/time v0.0.0-20220411224347-583f2d630306
@@ -68,6 +67,7 @@ require (
 	github.com/subosito/gotenv v1.2.0 // indirect
 	go.uber.org/atomic v1.9.0 // indirect
 	go.uber.org/goleak v1.1.12 // indirect
+	go.uber.org/multierr v1.8.0 // indirect
 	golang.org/x/crypto v0.0.0-20220411220226-7b82a4e95df4 // indirect
 	golang.org/x/image v0.5.0 // indirect
 	golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4 // indirect

--- a/internal/orchestration/deploy.go
+++ b/internal/orchestration/deploy.go
@@ -8,6 +8,7 @@ package orchestration
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"math/rand"
@@ -19,7 +20,6 @@ import (
 
 	"github.com/relab/iago"
 	fs "github.com/relab/wrfs"
-	"go.uber.org/multierr"
 )
 
 // DeployConfig contains configuration options for deployment.
@@ -155,16 +155,16 @@ func (ws WorkerSession) Stderr() io.Reader {
 
 // Close closes the session and all of its streams.
 func (ws WorkerSession) Close() (err error) {
-	err = multierr.Append(err, ws.cmd.Wait())
+	err = ws.cmd.Wait()
 	// apparently, closing the streams can return EOF, so we'll have to check for that.
 	if cerr := ws.stdin.Close(); cerr != nil && cerr != io.EOF {
-		err = multierr.Append(err, cerr)
+		err = errors.Join(err, cerr)
 	}
 	if cerr := ws.stdout.Close(); cerr != nil && cerr != io.EOF {
-		err = multierr.Append(err, cerr)
+		err = errors.Join(err, cerr)
 	}
 	if cerr := ws.stderr.Close(); cerr != nil && cerr != io.EOF {
-		err = multierr.Append(err, cerr)
+		err = errors.Join(err, cerr)
 	}
 	return
 }


### PR DESCRIPTION
Upgrades to Go 1.20 and replaces the multierr package with the new errors.Join function in stdlib.

