### PR TITLE
modules/registry: fix ListModules with interface types

### DIFF
--- a/modules/registry.go
+++ b/modules/registry.go
@@ -14,10 +14,11 @@ var (
 
 // RegisterModule registers a constructor for a module implementation with the specified name.
 // For example:
-//  RegisterModule("chainedhotstuff", func() consensus.Rules { return chainedhotstuff.New() })
+//
+//	RegisterModule("chainedhotstuff", func() consensus.Rules { return chainedhotstuff.New() })
 func RegisterModule[T any](name string, constructor func() T) {
 	var t T
-	moduleType := reflect.TypeOf(t)
+	moduleType := reflect.TypeOf(&t).Elem()
 
 	registryMut.Lock()
 	defer registryMut.Unlock()
@@ -39,7 +40,8 @@ func RegisterModule[T any](name string, constructor func() T) {
 // GetModule constructs a new instance of the module with the specified name.
 // GetModule returns true if the module is found, false otherwise.
 // For example:
-//  rules, ok := GetModule[consensus.Rules]("chainedhotstuff")
+//
+//	rules, ok := GetModule[consensus.Rules]("chainedhotstuff")
 func GetModule[T any](name string) (out T, ok bool) {
 	targetType := reflect.TypeOf(out)
 

--- a/modules/registry.go
+++ b/modules/registry.go
@@ -43,7 +43,7 @@ func RegisterModule[T any](name string, constructor func() T) {
 //
 //	rules, ok := GetModule[consensus.Rules]("chainedhotstuff")
 func GetModule[T any](name string) (out T, ok bool) {
-	targetType := reflect.TypeOf(out)
+	targetType := reflect.TypeOf(&out).Elem()
 
 	registryMut.Lock()
 	defer registryMut.Unlock()

--- a/modules/registry_test.go
+++ b/modules/registry_test.go
@@ -1,16 +1,34 @@
 package modules_test
 
 import (
+	"fmt"
+	"reflect"
 	"testing"
 
 	"github.com/relab/hotstuff/modules"
+	"golang.org/x/exp/slices"
 )
 
-func TestModuleRegistry(t *testing.T) {
+func init() {
+	// register some modules
 	modules.RegisterModule("frobulator", func() moduleIface {
 		return module{}
 	})
 
+	modules.RegisterModule("fizzbuzz", func() moduleIface {
+		return fizzbuzz{}
+	})
+
+	modules.RegisterModule("fizzer", func() fizzer {
+		return fizzbuzz{}
+	})
+
+	modules.RegisterModule("buzzer", func() buzzer {
+		return fizzbuzz{}
+	})
+}
+
+func TestModuleRegistry(t *testing.T) {
 	frobulator, ok := modules.GetModule[moduleIface]("frobulator")
 	if !ok {
 		t.Fatal("module was not found")
@@ -23,6 +41,32 @@ func TestModuleRegistry(t *testing.T) {
 	}
 }
 
+func TestListModules(t *testing.T) {
+	getName := func(t reflect.Type) string {
+		return fmt.Sprintf("(%s).%s", t.PkgPath(), t.Name())
+	}
+
+	want := map[string][]string{
+		getName(reflect.TypeOf((*moduleIface)(nil)).Elem()): {"frobulator", "fizzbuzz"},
+		getName(reflect.TypeOf((*fizzer)(nil)).Elem()):      {"fizzer"},
+		getName(reflect.TypeOf((*buzzer)(nil)).Elem()):      {"buzzer"},
+	}
+
+	list := modules.ListModules()
+
+	for iface, names := range want {
+		if got, ok := list[iface]; !ok {
+			t.Errorf("expected interface '%s' to be in list of modules", iface)
+		} else {
+			for _, name := range names {
+				if !slices.Contains(got, name) {
+					t.Errorf("expected '%s' to be in list of '%s' implementations", name, iface)
+				}
+			}
+		}
+	}
+}
+
 type moduleIface interface {
 	frobulate(i *int)
 }
@@ -32,3 +76,19 @@ type module struct{}
 func (module) frobulate(i *int) {
 	*i++
 }
+
+type fizzer interface {
+	fizz(i int)
+}
+
+type buzzer interface {
+	buzz(i int)
+}
+
+type fizzbuzz struct{}
+
+func (f fizzbuzz) fizz(_ int) { panic("not implemented") }
+
+func (f fizzbuzz) buzz(_ int) { panic("not implemented") }
+
+func (f fizzbuzz) frobulate(_ *int) { panic("not implemented") }


### PR DESCRIPTION
This was broken since fc203fc9

The problem is that RegisterModule looks at the zero value of a module's type. However, this does not work for interface types. A workaround is to get the type of a pointer to the interface and then access its element type.

Fixes #101 