### PR TITLE
Fix eddsa private key parsing bug

### DIFF
--- a/crypto/keygen/keygen.go
+++ b/crypto/keygen/keygen.go
@@ -233,7 +233,17 @@ func ParsePrivateKey(buf []byte) (key hotstuff.PrivateKey, err error) {
 	case ecdsacrypto.PrivateKeyFileType:
 		key, err = x509.ParseECPrivateKey(b.Bytes)
 	case eddsa.PrivateKeyFileType:
-		key = ed25519.NewKeyFromSeed(b.Bytes[:32])
+		//key = ed25519.NewKeyFromSeed(b.Bytes[:32])
+		var genericKey any
+		var ok bool
+		genericKey, err = x509.ParsePKCS8PrivateKey(b.Bytes)
+		if err != nil {
+			return nil, err
+		}
+		key, ok = genericKey.(ed25519.PrivateKey)
+		if !ok {
+			return nil, fmt.Errorf("failed to parse key")
+		}
 	case bls12.PrivateKeyFileType:
 		k := &bls12.PrivateKey{}
 		k.FromBytes(b.Bytes)

--- a/crypto/keygen/keygen.go
+++ b/crypto/keygen/keygen.go
@@ -233,13 +233,11 @@ func ParsePrivateKey(buf []byte) (key hotstuff.PrivateKey, err error) {
 	case ecdsacrypto.PrivateKeyFileType:
 		key, err = x509.ParseECPrivateKey(b.Bytes)
 	case eddsa.PrivateKeyFileType:
-		//key = ed25519.NewKeyFromSeed(b.Bytes[:32])
-		var genericKey any
-		var ok bool
-		genericKey, err = x509.ParsePKCS8PrivateKey(b.Bytes)
+		genericKey, err := x509.ParsePKCS8PrivateKey(b.Bytes)
 		if err != nil {
 			return nil, err
 		}
+		var ok bool
 		key, ok = genericKey.(ed25519.PrivateKey)
 		if !ok {
 			return nil, fmt.Errorf("failed to parse key")


### PR DESCRIPTION
The eddsa private key is encoded as PEM(PKCS#8) format. While decoding the private key a bug was introduced to generate a new key from the encoded bytes.
Fixed the issue by decoding the private key with same format.