### PR TITLE
Fix TimeoutMsgFromProto reported in issue 129

### DIFF
--- a/.vscode/dict.txt
+++ b/.vscode/dict.txt
@@ -10,6 +10,7 @@ Chursin
 clientpb
 cmdqueue
 Cmds
+cmpopts
 CODECOV
 covermode
 coverpkg

--- a/.vscode/dict.txt
+++ b/.vscode/dict.txt
@@ -3,6 +3,7 @@ Bano
 Baudet
 BFT's
 Bitfield
+bitmask
 cerr
 chainedhotstuff
 checkf
@@ -18,6 +19,7 @@ coverprofile
 cpuprofile
 Debugf
 durationpb
+dylib
 eddsa
 emptypb
 Erevik
@@ -29,6 +31,7 @@ Feng
 ferr
 fgprof
 fgprofprofile
+gcflags
 gocyclo
 golangci
 golint
@@ -37,6 +40,7 @@ gorums
 gpool
 grpc
 Gueta
+handelpb
 Hein
 hostnames
 HOTSTUFF
@@ -45,6 +49,7 @@ hotstuffpb
 iagotest
 ICDCS
 iface
+Iinternal
 Infof
 Jalalzai
 Jehl
@@ -52,6 +57,7 @@ Jianyu
 keygen
 kilic
 latencygen
+ldflags
 leaderrotation
 Malkhi
 Mathieu
@@ -73,6 +79,7 @@ propsed
 proto
 protobuf
 protoc
+protos
 protostream
 ptypes
 QC's

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -16,5 +16,17 @@
 	"go.testFlags": [
 		"-count=1"
 	],
-	"cSpell.enabled": true
+	"cSpell.enabled": true,
+	"cSpell.ignorePaths": [
+		"package-lock.json",
+		"node_modules",
+		"vscode-extension",
+		".git/{info,lfs,logs,refs,objects}/**",
+		".git/{index,*refs,*HEAD}",
+		".vscode",
+		".vscode-insiders",
+		"go.mod",
+		"go.sum",
+		"**/**/*.pb.go"
+	]
 }

--- a/crypto/bls12/bls12.go
+++ b/crypto/bls12/bls12.go
@@ -320,7 +320,7 @@ func (bls *bls12Base) fastAggregateVerify(publicKeys []*PublicKey, message []byt
 	return bls.coreVerify(&PublicKey{p: &aggregate}, message, signature, domain)
 }
 
-// Sign creates a cryptographic signature of the given messsage.
+// Sign creates a cryptographic signature of the given message.
 func (bls *bls12Base) Sign(message []byte) (signature hotstuff.QuorumSignature, err error) {
 	p, err := bls.coreSign(message, domain)
 	if err != nil {

--- a/docs/experimentation.md
+++ b/docs/experimentation.md
@@ -235,7 +235,7 @@ these additional flags are used:
 - `--worker` runs a worker locally, in addition to the remote hosts specified. Use this if you want the local machine
   to participate in the experiment.
 
-Additionally, it is possible to specify an *internal address* for each host.
+Additionally, it is possible to specify an _internal address_ for each host.
 The internal address is used by replicas instead of the address used by the controller.
 This is useful if the controller is connecting to the remote hosts using a global address,
 whereas the hosts can communicate using local addresses.
@@ -243,11 +243,11 @@ The internal address is configured through the configuration file (loaded by the
 
 ```toml
 [[hosts-config]]
-name = "hotstuff_worker_1"
+name = "hotstuff-worker-1"
 internal-address = "192.168.10.2"
 
 [[hosts-config]]
-name = "hotstuff_worker_1"
+name = "hotstuff-worker-1"
 internal-address = "192.168.10.3"
 ```
 
@@ -262,21 +262,21 @@ The following shows a configuration file that customizes the client and replica 
 clients = 2
 replicas = 8
 
-hosts = [ 
-    "hotstuff_worker_1",
-    "hotstuff_worker_2",
-    "hotstuff_worker_3",
-    "hotstuff_worker_4",
+hosts = [
+    "hotstuff-worker-1",
+    "hotstuff-worker-2",
+    "hotstuff-worker-3",
+    "hotstuff-worker-4",
 ]
 
 # specific assignments for some hosts
 [[hosts-config]]
-name = "hotstuff_worker_1"
+name = "hotstuff-worker-1"
 clients = 2
 replicas = 0
 ```
 
-In particular, in this example the host named `hotstuff_worker_1` is configured to run both clients and no replicas.
+In particular, in this example the host named `hotstuff-worker-1` is configured to run both clients and no replicas.
 The remaining replicas are divided among the remaining hosts. If all hosts are manually configured, the total number of
 clients and replicas configured must equal the requested number of clients and replicas.
 

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/felixge/fgprof v0.9.4
 	github.com/golang/mock v1.6.0
 	github.com/golang/protobuf v1.5.4
+	github.com/google/go-cmp v0.6.0
 	github.com/kilic/bls12-381 v0.1.1-0.20210208205449-6045b0235e36
 	github.com/mattn/go-isatty v0.0.20
 	github.com/mitchellh/go-homedir v1.1.0
@@ -46,7 +47,6 @@ require (
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0 // indirect
 	github.com/gonuts/binary v0.2.0 // indirect
-	github.com/google/go-cmp v0.6.0 // indirect
 	github.com/google/pprof v0.0.0-20240227163752-401108e1b7e7 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect

--- a/internal/proto/hotstuffpb/convert.go
+++ b/internal/proto/hotstuffpb/convert.go
@@ -162,7 +162,7 @@ func TimeoutMsgFromProto(m *TimeoutMsg) hotstuff.TimeoutMsg {
 		SyncInfo:      SyncInfoFromProto(m.GetSyncInfo()),
 		ViewSignature: QuorumSignatureFromProto(m.GetViewSig()),
 	}
-	if m.GetViewSig() != nil {
+	if m.GetMsgSig() != nil {
 		timeoutMsg.MsgSignature = QuorumSignatureFromProto(m.GetMsgSig())
 	}
 	return timeoutMsg

--- a/scripts/deploy_test.sh
+++ b/scripts/deploy_test.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-join () {
+join() {
 	local IFS="$1"
 	shift
 	echo "$*"
@@ -10,10 +10,9 @@ num_hosts=4
 
 declare -A hosts
 
-for ((i=1; i<=num_hosts; i++)); do
+for ((i = 1; i <= num_hosts; i++)); do
 	hosts[$i]="hotstuff_worker_$i"
 done
-
 
 if [ ! -f "./id" ]; then
 	ssh-keygen -t ed25519 -C "hotstuff-test" -f "./id" -N ""
@@ -21,12 +20,12 @@ fi
 
 compose_args="--project-name=hotstuff"
 
-docker-compose $compose_args up -d --build --scale worker=4
+docker compose $compose_args up -d --build --scale worker=4
 
-docker-compose $compose_args exec -T controller /bin/sh -c "ssh-keyscan -H $(join ' ' "${hosts[@]}") >> ~/.ssh/known_hosts" &>/dev/null
-docker-compose $compose_args exec -T controller /bin/sh -c "hotstuff run --hosts '$(join ',' "${hosts[@]}")' --config ./example_config.toml --log-level info"
+docker compose $compose_args exec -T controller /bin/sh -c "ssh-keyscan -H $(join ' ' "${hosts[@]}") >> ~/.ssh/known_hosts" &>/dev/null
+docker compose $compose_args exec -T controller /bin/sh -c "hotstuff run --hosts '$(join ',' "${hosts[@]}")' --config ./example_config.toml --log-level info"
 exit_code="$?"
 
-docker-compose $compose_args down
+docker compose $compose_args down
 
 exit $exit_code

--- a/scripts/deploy_test.sh
+++ b/scripts/deploy_test.sh
@@ -11,7 +11,7 @@ num_hosts=4
 declare -A hosts
 
 for ((i = 1; i <= num_hosts; i++)); do
-	hosts[$i]="hotstuff_worker_$i"
+	hosts[$i]="hotstuff-worker-$i"
 done
 
 if [ ! -f "./id" ]; then

--- a/scripts/docker-compose.yml
+++ b/scripts/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   worker:
     build:

--- a/scripts/example_config.toml
+++ b/scripts/example_config.toml
@@ -8,7 +8,7 @@ hosts = [
 	"hotstuff_worker_4",
 ]
 
-# specific assingments for some hosts
+# specific assignments for some hosts
 [[hosts-config]]
 name = "hotstuff_worker_1"
 clients = 2

--- a/scripts/example_config.toml
+++ b/scripts/example_config.toml
@@ -1,15 +1,15 @@
 clients = 2
 replicas = 8
 
-hosts = [ 
-	"hotstuff_worker_1",
-	"hotstuff_worker_2",
-	"hotstuff_worker_3",
-	"hotstuff_worker_4",
+hosts = [
+	"hotstuff-worker-1",
+	"hotstuff-worker-2",
+	"hotstuff-worker-3",
+	"hotstuff-worker-4",
 ]
 
 # specific assignments for some hosts
 [[hosts-config]]
-name = "hotstuff_worker_1"
+name = "hotstuff-worker-1"
 clients = 2
 replicas = 0

--- a/scripts/single_worker.sh
+++ b/scripts/single_worker.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-image="hotstuff_worker"
+image="hotstuff-worker"
 
 if [ ! -f "./id" ]; then
 	ssh-keygen -t ed25519 -C "hotstuff-test" -f "./id" -N ""

--- a/scripts/single_worker.sh
+++ b/scripts/single_worker.sh
@@ -7,14 +7,14 @@ if [ ! -f "./id" ]; then
 fi
 
 # ensure that the image is built
-docker images | grep "$image" &>/dev/null \
-	|| docker build -t "$image" -f "./Dockerfile.worker" ".."
+docker images | grep "$image" &>/dev/null ||
+	docker build -t "$image" -f "./Dockerfile.worker" ".."
 
 container="$(docker run --rm -d -p 2020:22 -p 4000:4000 "$image")"
 
 sleep 1s
 
-ssh-keyscan -p 2020 127.0.0.1 localhost > known_hosts
+ssh-keyscan -p 2020 127.0.0.1 localhost >known_hosts
 
 docker logs --follow "$container"
 docker rm -f "$container" &>/dev/null

--- a/scripts/ssh_config
+++ b/scripts/ssh_config
@@ -1,5 +1,5 @@
 # ssh_config used with the controller container
 
-Host hotstuff_worker_*
+Host hotstuff-worker-*
 	User root
 	IdentityFile ~/.ssh/id


### PR DESCRIPTION
When initializing the TimeoutMsg.MsgSignature field it required
that the TimeoutMsg's ViewSignature was non-nil instead of checking
for the MsgSignature being non-nil.

It is not clear to me if this can happen in practice, but this
fixes the problem.

Thanks to @ikmOfSA for reporting the bug.

Fixes #129

