### PR TITLE
Remove deprecated grpc API calls

### DIFF
--- a/backend/config.go
+++ b/backend/config.go
@@ -110,8 +110,6 @@ func NewConfig(creds credentials.TransportCredentials, opts ...gorums.ManagerOpt
 		creds = insecure.NewCredentials()
 	}
 	grpcOpts := []grpc.DialOption{
-		grpc.WithBlock(),
-		grpc.WithReturnConnectionError(),
 		grpc.WithTransportCredentials(creds),
 	}
 	opts = append(opts, gorums.WithGrpcDialOptions(grpcOpts...))

--- a/client/client.go
+++ b/client/client.go
@@ -106,18 +106,14 @@ func New(conf Config, builder modules.Builder) (client *Client) {
 
 	builder.Build()
 
-	grpcOpts := []grpc.DialOption{}
-
 	var creds credentials.TransportCredentials
 	if conf.TLS {
 		creds = credentials.NewClientTLSFromCert(conf.RootCAs, "")
 	} else {
 		creds = insecure.NewCredentials()
 	}
-	grpcOpts = append(grpcOpts, grpc.WithTransportCredentials(creds))
 
-	opts := conf.ManagerOptions
-	opts = append(opts, gorums.WithGrpcDialOptions(grpcOpts...))
+	opts := append(conf.ManagerOptions, gorums.WithGrpcDialOptions(grpc.WithTransportCredentials(creds)))
 
 	client.mgr = clientpb.NewManager(opts...)
 

--- a/client/client.go
+++ b/client/client.go
@@ -106,7 +106,7 @@ func New(conf Config, builder modules.Builder) (client *Client) {
 
 	builder.Build()
 
-	grpcOpts := []grpc.DialOption{grpc.WithBlock()}
+	grpcOpts := []grpc.DialOption{}
 
 	var creds credentials.TransportCredentials
 	if conf.TLS {

--- a/internal/orchestration/worker.go
+++ b/internal/orchestration/worker.go
@@ -28,7 +28,6 @@ import (
 	"github.com/relab/hotstuff/modules"
 	"github.com/relab/hotstuff/replica"
 	"github.com/relab/hotstuff/synchronizer"
-	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
@@ -230,7 +229,6 @@ func (w *Worker) createReplica(opts *orchestrationpb.ReplicaOpts) (*replica.Repl
 		BatchSize:   opts.GetBatchSize(),
 		ManagerOptions: []gorums.ManagerOption{
 			gorums.WithDialTimeout(opts.GetConnectTimeout().AsDuration()),
-			gorums.WithGrpcDialOptions(grpc.WithReturnConnectionError()),
 		},
 	}
 	return replica.New(c, builder), nil
@@ -292,7 +290,6 @@ func (w *Worker) startClients(req *orchestrationpb.StartClientRequest) (*orchest
 			Input:         io.NopCloser(rand.Reader),
 			ManagerOptions: []gorums.ManagerOption{
 				gorums.WithDialTimeout(opts.GetConnectTimeout().AsDuration()),
-				gorums.WithGrpcDialOptions(grpc.WithReturnConnectionError()),
 			},
 			RateLimit:        opts.GetRateLimit(),
 			RateStep:         opts.GetRateStep(),


### PR DESCRIPTION
Fixes #141

`WithBlock` and `WithReturnConnectionError` have been removed from:

https://github.com/relab/hotstuff/blob/e517711f0cea3d0024a9d8a421595cb3a4e83141/backend/config.go#L113

Code works seemingly correctly. Tests pass and binary runs fine with the default config.