### PR TITLE
Fix #148 - Location config bug

### DIFF
--- a/internal/latency/latency.go
+++ b/internal/latency/latency.go
@@ -19,7 +19,7 @@ func Between(a, b string) time.Duration {
 
 // ValidLocation returns the location if it is valid, or an error otherwise.
 func ValidLocation(location string) (string, error) {
-	if location == "" {
+	if location == "" || location == DefaultLocation {
 		return DefaultLocation, nil
 	}
 	if !slices.Contains(allLocations, location) {

--- a/internal/latency/latency.go
+++ b/internal/latency/latency.go
@@ -67,9 +67,6 @@ func MatrixFrom(locations []string) Matrix {
 // Latency returns the latency between nodes a and b.
 // If a or b are not valid nodes, the function will panic.
 func (lm Matrix) Latency(a, b hotstuff.ID) time.Duration {
-	if a == b {
-		return 0
-	}
 	return lm.lm[a-1][b-1]
 }
 

--- a/internal/latency/latency.go
+++ b/internal/latency/latency.go
@@ -38,12 +38,6 @@ type Matrix struct {
 // MatrixFrom returns the latencies between the given locations.
 // If a location is not valid, the function will panic.
 func MatrixFrom(locations []string) Matrix {
-	if len(locations) == 0 {
-		return Matrix{
-			enabled: false,
-		}
-	}
-
 	locationIndices := make([]int, len(locations))
 	for i, loc := range locations {
 		if loc == DefaultLocation {

--- a/internal/latency/latency.go
+++ b/internal/latency/latency.go
@@ -38,6 +38,12 @@ type Matrix struct {
 // MatrixFrom returns the latencies between the given locations.
 // If a location is not valid, the function will panic.
 func MatrixFrom(locations []string) Matrix {
+	if len(locations) == 0 {
+		return Matrix{
+			enabled: false,
+		}
+	}
+
 	locationIndices := make([]int, len(locations))
 	for i, loc := range locations {
 		if loc == DefaultLocation {

--- a/internal/latency/latency.go
+++ b/internal/latency/latency.go
@@ -67,6 +67,9 @@ func MatrixFrom(locations []string) Matrix {
 // Latency returns the latency between nodes a and b.
 // If a or b are not valid nodes, the function will panic.
 func (lm Matrix) Latency(a, b hotstuff.ID) time.Duration {
+	if a == b {
+		return 0
+	}
 	return lm.lm[a-1][b-1]
 }
 

--- a/internal/orchestration/controller.go
+++ b/internal/orchestration/controller.go
@@ -184,6 +184,7 @@ func (e *Experiment) assignReplicasAndClients() (err error) {
 	e.hostsToClients = make(map[string][]hotstuff.ID)
 	replicaLocations := make([]string, 0, e.NumReplicas)
 	nextReplicaID := hotstuff.ID(1)
+	nextReplicaIDAgain := nextReplicaID
 	nextClientID := hotstuff.ID(1)
 
 	// number of replicas that should be auto assigned
@@ -275,12 +276,18 @@ func (e *Experiment) assignReplicasAndClients() (err error) {
 			replicaOpts.ID = uint32(nextReplicaID)
 			replicaOpts.ByzantineStrategy = byzantineStrategy
 			replicaLocations = append(replicaLocations, location)
-			// all replicaOpts share the same Locations slice, which is progressively updated
-			replicaOpts.Locations = replicaLocations
+
 			e.hostsToReplicas[host] = append(e.hostsToReplicas[host], nextReplicaID)
 			e.replicaOpts[nextReplicaID] = replicaOpts
 			e.Logger.Infof("replica %d assigned to host %s", nextReplicaID, host)
 			nextReplicaID++
+		}
+
+		for i := 0; i < numReplicas; i++ {
+			replicaOpts := e.replicaOpts[nextReplicaID]
+			// all replicaOpts share the same Locations slice, which is progressively updated
+			replicaOpts.Locations = replicaLocations
+			nextReplicaIDAgain++
 		}
 
 		for i := 0; i < numClients; i++ {

--- a/internal/orchestration/controller.go
+++ b/internal/orchestration/controller.go
@@ -276,8 +276,9 @@ func (e *Experiment) assignReplicasAndClients() (err error) {
 			replicaOpts := proto.Clone(e.ReplicaOpts).(*orchestrationpb.ReplicaOpts)
 			replicaOpts.ID = uint32(nextReplicaID)
 			replicaOpts.ByzantineStrategy = byzantineStrategy
+			// Progressively updating the locations slice to ensure all locations are known.
+			// This slice is added to each replica options in a later loop.
 			replicaLocations = append(replicaLocations, location)
-			// all replicaOpts share the same Locations slice, which is progressively updated
 			e.hostsToReplicas[host] = append(e.hostsToReplicas[host], nextReplicaID)
 			e.replicaOpts[nextReplicaID] = replicaOpts
 			e.Logger.Infof("replica %d assigned to host %s", nextReplicaID, host)

--- a/internal/orchestration/controller.go
+++ b/internal/orchestration/controller.go
@@ -183,8 +183,8 @@ func (e *Experiment) assignReplicasAndClients() (err error) {
 	e.replicaOpts = make(map[hotstuff.ID]*orchestrationpb.ReplicaOpts)
 	e.hostsToClients = make(map[string][]hotstuff.ID)
 	replicaLocations := make([]string, 0, e.NumReplicas)
-	nextReplicaID := hotstuff.ID(1)
-	nextReplicaIDAgain := nextReplicaID
+	initialReplicaID := hotstuff.ID(1)
+	nextReplicaID := initialReplicaID
 	nextClientID := hotstuff.ID(1)
 
 	// number of replicas that should be auto assigned
@@ -283,11 +283,13 @@ func (e *Experiment) assignReplicasAndClients() (err error) {
 			nextReplicaID++
 		}
 
+		// Need to iterate again to give the full list of locations
+		nextReplicaID = initialReplicaID // Reset to initial ID
 		for i := 0; i < numReplicas; i++ {
 			replicaOpts := e.replicaOpts[nextReplicaID]
 			// all replicaOpts share the same Locations slice, which is progressively updated
 			replicaOpts.Locations = replicaLocations
-			nextReplicaIDAgain++
+			nextReplicaID++
 		}
 
 		for i := 0; i < numClients; i++ {

--- a/internal/orchestration/controller.go
+++ b/internal/orchestration/controller.go
@@ -183,8 +183,7 @@ func (e *Experiment) assignReplicasAndClients() (err error) {
 	e.replicaOpts = make(map[hotstuff.ID]*orchestrationpb.ReplicaOpts)
 	e.hostsToClients = make(map[string][]hotstuff.ID)
 	replicaLocations := make([]string, 0, e.NumReplicas)
-	initialReplicaID := hotstuff.ID(1)
-	nextReplicaID := initialReplicaID
+	nextReplicaID := hotstuff.ID(1)
 	nextClientID := hotstuff.ID(1)
 
 	// number of replicas that should be auto assigned
@@ -276,19 +275,11 @@ func (e *Experiment) assignReplicasAndClients() (err error) {
 			replicaOpts.ID = uint32(nextReplicaID)
 			replicaOpts.ByzantineStrategy = byzantineStrategy
 			replicaLocations = append(replicaLocations, location)
-
+			// all replicaOpts share the same Locations slice, which is progressively updated
+			replicaOpts.Locations = replicaLocations
 			e.hostsToReplicas[host] = append(e.hostsToReplicas[host], nextReplicaID)
 			e.replicaOpts[nextReplicaID] = replicaOpts
 			e.Logger.Infof("replica %d assigned to host %s", nextReplicaID, host)
-			nextReplicaID++
-		}
-
-		// Need to iterate again to give the full list of locations
-		nextReplicaID = initialReplicaID // Reset to initial ID
-		for i := 0; i < numReplicas; i++ {
-			replicaOpts := e.replicaOpts[nextReplicaID]
-			// all replicaOpts share the same Locations slice, which is progressively updated
-			replicaOpts.Locations = replicaLocations
 			nextReplicaID++
 		}
 

--- a/internal/orchestration/controller.go
+++ b/internal/orchestration/controller.go
@@ -293,16 +293,21 @@ func (e *Experiment) assignReplicasAndClients() (err error) {
 		}
 	}
 
+	e.populateReplicaLocations(totalReplicaCount, initialReplicaID, replicaLocations)
+
+	// TODO: warn if not all clients/replicas were assigned
+	return nil
+}
+
+// This function exists to fix the cyclomatic complexity lint error.
+func (e *Experiment) populateReplicaLocations(totalReplicaCount int, initialReplicaID hotstuff.ID, replicaLocations []string) {
 	// Reiterate the replicas to supply the full list of locations.
-	nextReplicaID = initialReplicaID
+	nextReplicaID := initialReplicaID
 	for range totalReplicaCount {
 		replicaOpts := e.replicaOpts[nextReplicaID]
 		replicaOpts.Locations = replicaLocations
 		nextReplicaID++
 	}
-
-	// TODO: warn if not all clients/replicas were assigned
-	return nil
 }
 
 type assignmentsFileContents struct {

--- a/scripts/local_config.toml
+++ b/scripts/local_config.toml
@@ -1,0 +1,11 @@
+clients = 2
+replicas = 4
+
+#locations = ["Melbourne", "Rome", "Amsterdam", "Barcelona", "Gothenburg"]
+
+# specific assignments for some hosts
+[[hosts-config]]
+name="localhost"
+clients = 2
+replicas = 4
+location = "Melbourne"


### PR DESCRIPTION
Tested on bbchain-cluster with `bb1` as controller and it works like intended. Using the following configuration:

```
clients = 2
replicas = 4

hosts = [
        "bb2",
        "bb3",
        "bb4",
        "bb5",
        "bb6",
]

# specific assignments for some hosts
[[hosts-config]]
name = "bb2"
clients = 2
replicas = 0
location = "Melbourne"

[[hosts-config]]
name = "bb3"
clients = 0
replicas = 1
location = "Rome"

[[hosts-config]]
name = "bb4"
clients = 0
replicas = 1
location = "Amsterdam"

[[hosts-config]]
name = "bb5"
clients = 0
replicas = 1
location = "Barcelona"

[[hosts-config]]
name = "bb6"
clients = 0
replicas = 1
location = "Gothenburg"
```

The additional `scripts/local_config.toml` can also be used to run local tests, but the latency values will be zero.