### PR TITLE
Remove deprecated observer pattern in event loop.

### DIFF
--- a/consensus/consensus_test.go
+++ b/consensus/consensus_test.go
@@ -35,10 +35,10 @@ func TestVote(t *testing.T) {
 
 	ok := false
 	ctx, cancel := context.WithCancel(context.Background())
-	eventLoop.RegisterObserver(hotstuff.NewViewMsg{}, func(_ any) {
+	eventLoop.RegisterHandler(hotstuff.NewViewMsg{}, func(_ any) {
 		ok = true
 		cancel()
-	})
+	}, eventloop.Prioritize())
 
 	b := testutil.NewProposeMsg(
 		hotstuff.GetGenesis().Hash(),

--- a/eventloop/eventloop.go
+++ b/eventloop/eventloop.go
@@ -77,18 +77,6 @@ func New(bufferSize uint) *EventLoop {
 	return el
 }
 
-// RegisterObserver registers a handler with priority.
-// Deprecated: use RegisterHandler and the Prioritize option instead.
-func (el *EventLoop) RegisterObserver(eventType any, handler EventHandler) int {
-	return el.registerHandler(eventType, []HandlerOption{Prioritize()}, handler)
-}
-
-// UnregisterObserver unregister a handler.
-// Deprecated: use UnregisterHandler instead.
-func (el *EventLoop) UnregisterObserver(eventType any, id int) {
-	el.UnregisterHandler(eventType, id)
-}
-
 // RegisterHandler registers the given event handler for the given event type with the given handler options, if any.
 // If no handler options are provided, the default handler options will be used.
 func (el *EventLoop) RegisterHandler(eventType any, handler EventHandler, opts ...HandlerOption) int {

--- a/metrics/clientlatency.go
+++ b/metrics/clientlatency.go
@@ -43,9 +43,9 @@ func (lr *ClientLatency) InitModule(mods *modules.Core) {
 		lr.addLatency(latencyEvent.Latency)
 	})
 
-	eventLoop.RegisterObserver(types.TickEvent{}, func(event any) {
+	eventLoop.RegisterHandler(types.TickEvent{}, func(event any) {
 		lr.tick(event.(types.TickEvent))
-	})
+	}, eventloop.Prioritize())
 
 	logger.Info("Client Latency metric enabled")
 }

--- a/metrics/throughput.go
+++ b/metrics/throughput.go
@@ -46,9 +46,9 @@ func (t *Throughput) InitModule(mods *modules.Core) {
 		t.recordCommit(commitEvent.Commands)
 	})
 
-	eventLoop.RegisterObserver(types.TickEvent{}, func(event any) {
+	eventLoop.RegisterHandler(types.TickEvent{}, func(event any) {
 		t.tick(event.(types.TickEvent))
-	})
+	}, eventloop.Prioritize())
 
 	logger.Info("Throughput metric enabled")
 }

--- a/metrics/timeouts.go
+++ b/metrics/timeouts.go
@@ -45,9 +45,9 @@ func (vt *ViewTimeouts) InitModule(mods *modules.Core) {
 		vt.viewChange(event.(synchronizer.ViewChangeEvent))
 	})
 
-	eventLoop.RegisterObserver(types.TickEvent{}, func(event any) {
+	eventLoop.RegisterHandler(types.TickEvent{}, func(event any) {
 		vt.tick(event.(types.TickEvent))
-	})
+	}, eventloop.Prioritize())
 }
 
 func (vt *ViewTimeouts) viewChange(event synchronizer.ViewChangeEvent) {

--- a/twins/network.go
+++ b/twins/network.go
@@ -465,12 +465,12 @@ func (tm *timeoutManager) InitModule(mods *modules.Core) {
 		&tm.eventLoop,
 	)
 
-	tm.eventLoop.RegisterObserver(tick{}, func(_ any) {
+	tm.eventLoop.RegisterHandler(tick{}, func(_ any) {
 		tm.advance()
-	})
-	tm.eventLoop.RegisterObserver(synchronizer.ViewChangeEvent{}, func(event any) {
+	}, eventloop.Prioritize())
+	tm.eventLoop.RegisterHandler(synchronizer.ViewChangeEvent{}, func(event any) {
 		tm.viewChange(event.(synchronizer.ViewChangeEvent))
-	})
+	}, eventloop.Prioritize())
 }
 
 // FixedTimeout returns an ExponentialTimeout with a max exponent of 0.


### PR DESCRIPTION
Fixes #160

All references to `RegisterObserver` have been removed and replaced with `RegisterHandler` and the `Prioritize`.

Tests pass and things run as expected.