### PR TITLE
Add tests for emulatedSender's network funcs and replace IDSet with simple []hotstuff.ID

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,11 +1,10 @@
 module github.com/relab/hotstuff
 
-go 1.23.4
+go 1.24.3
 
 require (
 	cuelang.org/go v0.11.1
 	github.com/felixge/fgprof v0.9.5
-	github.com/golang/protobuf v1.5.4
 	github.com/google/go-cmp v0.6.0
 	github.com/kilic/bls12-381 v0.1.1-0.20210208205449-6045b0235e36
 	github.com/mattn/go-isatty v0.0.20

--- a/twins/generator.go
+++ b/twins/generator.go
@@ -28,7 +28,7 @@ func assignNodeIDs(numNodes, numTwins uint8) (nodes, twins []NodeID) {
 	remainingTwins := numTwins
 
 	// assign IDs to nodes
-	for i := uint8(0); i < numNodes; i++ {
+	for range numNodes {
 		if remainingTwins > 0 {
 			twins = append(twins, NodeID{
 				ReplicaID: replicaID,

--- a/twins/network.go
+++ b/twins/network.go
@@ -375,7 +375,7 @@ func (s *emulatedSender) shouldDrop(id NodeID, message any) bool {
 	return s.network.shouldDrop(s.node.id.NetworkID, id.NetworkID, message)
 }
 
-// GetSubConfig returns a subconfiguration containing the replicas specified in the ids slice.
+// Sub returns a subconfiguration containing the replicas specified in the ids slice.
 func (s *emulatedSender) Sub(ids []hotstuff.ID) (sub modules.Sender, err error) {
 	return &emulatedSender{
 		node:      s.node,
@@ -395,6 +395,7 @@ func (s *emulatedSender) Timeout(msg hotstuff.TimeoutMsg) {
 	s.broadcastMessage(msg)
 }
 
+// Vote sends the partial cert to the replica.
 func (s *emulatedSender) Vote(id hotstuff.ID, cert hotstuff.PartialCert) error {
 	if _, ok := s.network.replicas[id]; !ok {
 		return fmt.Errorf("replica with id %d not found", id)
@@ -406,6 +407,7 @@ func (s *emulatedSender) Vote(id hotstuff.ID, cert hotstuff.PartialCert) error {
 	return nil
 }
 
+// NewView sends the new view message to the replica.
 func (s *emulatedSender) NewView(id hotstuff.ID, si hotstuff.SyncInfo) error {
 	if _, ok := s.network.replicas[id]; !ok {
 		return fmt.Errorf("replica with id %d not found", id)

--- a/twins/network.go
+++ b/twins/network.go
@@ -165,6 +165,13 @@ type pendingMessage struct {
 	receiver uint32
 }
 
+func (pm pendingMessage) String() string {
+	if pm.message == nil {
+		return fmt.Sprintf("%d→%d", pm.sender, pm.receiver)
+	}
+	return fmt.Sprintf("%d→%d: %v", pm.sender, pm.receiver, pm.message)
+}
+
 // Network is a simulated network that supports twins.
 type Network struct {
 	nodes map[uint32]*node
@@ -185,12 +192,19 @@ type Network struct {
 }
 
 // NewSimpleNetwork creates a simple network.
-func NewSimpleNetwork() *Network {
-	return &Network{
+func NewSimpleNetwork(numNodes int) *Network {
+	allNodesSet := make(NodeSet)
+	for i := 1; i <= numNodes; i++ {
+		allNodesSet.Add(uint32(i))
+	}
+	network := &Network{
 		nodes:     make(map[uint32]*node),
 		replicas:  make(map[hotstuff.ID][]*node),
+		views:     []View{{Leader: 1, Partitions: []NodeSet{allNodesSet}}},
 		dropTypes: make(map[reflect.Type]struct{}),
 	}
+	network.logger = logging.NewWithDest(&network.log, "network")
+	return network
 }
 
 // NewPartitionedNetwork creates a new Network with the specified partitions.

--- a/twins/network.go
+++ b/twins/network.go
@@ -226,7 +226,7 @@ func NewPartitionedNetwork(views []View, dropTypes ...any) *Network {
 func (n *Network) createTwinsNodes(nodes []NodeID, consensusName string) (errs error) {
 	for _, nodeID := range nodes {
 		node, err := newNode(n, nodeID, consensusName)
-		errs = errors.Join(err)
+		errs = errors.Join(errs, err)
 		n.nodes[nodeID.NetworkID] = node
 		n.replicas[nodeID.ReplicaID] = append(n.replicas[nodeID.ReplicaID], node)
 	}

--- a/twins/network.go
+++ b/twins/network.go
@@ -3,7 +3,6 @@ package twins
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"maps"
 	"reflect"
@@ -219,10 +218,12 @@ func NewPartitionedNetwork(views []View, dropTypes ...any) *Network {
 	return n
 }
 
-func (n *Network) createTwinsNodes(nodes []NodeID, consensusName string) (errs error) {
+func (n *Network) createTwinsNodes(nodes []NodeID, consensusName string) error {
 	for _, nodeID := range nodes {
 		node, err := newNode(n, nodeID, consensusName)
-		errs = errors.Join(errs, err)
+		if err != nil {
+			return fmt.Errorf("failed to create node %v: %w", nodeID, err)
+		}
 		n.nodes[nodeID.NetworkID] = node
 		n.replicas[nodeID.ReplicaID] = append(n.replicas[nodeID.ReplicaID], node)
 	}
@@ -240,7 +241,7 @@ func (n *Network) createTwinsNodes(nodes []NodeID, consensusName string) (errs e
 			})
 		}
 	}
-	return
+	return nil
 }
 
 func (n *Network) run(ticks int) {

--- a/twins/network_test.go
+++ b/twins/network_test.go
@@ -90,7 +90,6 @@ func TestNetworkSubConfigBroadcastMessage(t *testing.T) {
 		{name: "self/sender=6/receivers=6", msg: t1, sender: 6, receivers: []hotstuff.ID{1, 3, 4, 5, 6, 7}, want: []pendingMessage{{t1, 6, 1}, {t1, 6, 3}, {t1, 6, 4}, {t1, 6, 5}, {t1, 6, 7}}},
 		{name: "self/sender=7/receivers=6", msg: t1, sender: 7, receivers: []hotstuff.ID{1, 2, 4, 5, 6, 7}, want: []pendingMessage{{t1, 7, 1}, {t1, 7, 2}, {t1, 7, 4}, {t1, 7, 5}, {t1, 7, 6}}},
 		// sender is not part of the receivers list.
-		{name: "no_self/sender=1/receivers=0", msg: t1, sender: 1, receivers: []hotstuff.ID{}, want: []pendingMessage{}},
 		{name: "no_self/sender=1/receivers=1", msg: t1, sender: 1, receivers: []hotstuff.ID{2}, want: []pendingMessage{{t1, 1, 2}}},
 		{name: "no_self/sender=1/receivers=2", msg: t1, sender: 1, receivers: []hotstuff.ID{2, 3}, want: []pendingMessage{{t1, 1, 2}, {t1, 1, 3}}},
 		{name: "no_self/sender=1/receivers=3", msg: t1, sender: 1, receivers: []hotstuff.ID{2, 3, 4}, want: []pendingMessage{{t1, 1, 2}, {t1, 1, 3}, {t1, 1, 4}}},
@@ -144,7 +143,6 @@ func BenchmarkNetworkSubConfigBroadcastMessage(b *testing.B) {
 		{name: "self/sender=6/receivers=6", msg: t1, sender: 6, receivers: []hotstuff.ID{1, 3, 4, 5, 6, 7}, want: []pendingMessage{{t1, 6, 1}, {t1, 6, 3}, {t1, 6, 4}, {t1, 6, 5}, {t1, 6, 7}}},
 		{name: "self/sender=7/receivers=6", msg: t1, sender: 7, receivers: []hotstuff.ID{1, 2, 4, 5, 6, 7}, want: []pendingMessage{{t1, 7, 1}, {t1, 7, 2}, {t1, 7, 4}, {t1, 7, 5}, {t1, 7, 6}}},
 		// sender is not part of the receivers list.
-		{name: "no_self/sender=1/receivers=0", msg: t1, sender: 1, receivers: []hotstuff.ID{}, want: []pendingMessage{}},
 		{name: "no_self/sender=1/receivers=1", msg: t1, sender: 1, receivers: []hotstuff.ID{2}, want: []pendingMessage{{t1, 1, 2}}},
 		{name: "no_self/sender=1/receivers=2", msg: t1, sender: 1, receivers: []hotstuff.ID{2, 3}, want: []pendingMessage{{t1, 1, 2}, {t1, 1, 3}}},
 		{name: "no_self/sender=1/receivers=3", msg: t1, sender: 1, receivers: []hotstuff.ID{2, 3, 4}, want: []pendingMessage{{t1, 1, 2}, {t1, 1, 3}, {t1, 1, 4}}},

--- a/twins/network_test.go
+++ b/twins/network_test.go
@@ -168,7 +168,7 @@ func createNetwork(t testing.TB, numNodes int) (*Network, []*emulatedSender) {
 	}
 	senders := make([]*emulatedSender, len(network.nodes))
 	for i, node := range network.nodes {
-		senders[i-1] = network.NewSender(node)
+		senders[i-1] = newSender(network, node)
 	}
 	return network, senders
 }

--- a/twins/network_test.go
+++ b/twins/network_test.go
@@ -121,7 +121,57 @@ func TestNetworkSubConfigBroadcastMessage(t *testing.T) {
 	checkAllMessages(t, gotPendingMessages, wantPendingMessages)
 }
 
-func createNetwork(t *testing.T, numNodes int) (*Network, []*emulatedSender) {
+func BenchmarkNetworkSubConfigBroadcastMessage(b *testing.B) {
+	network, senders := createNetwork(b, 7)
+
+	t1 := hotstuff.TimeoutMsg{ID: 1, View: 1}
+	tests := []struct {
+		name      string
+		msg       hotstuff.TimeoutMsg
+		sender    hotstuff.ID
+		receivers []hotstuff.ID
+		want      []pendingMessage
+	}{
+		// sender is also part of the receivers list, but it will not send to itself.
+		{name: "self/sender=1/receivers=1", msg: t1, sender: 1, receivers: []hotstuff.ID{1}, want: []pendingMessage{}},
+		{name: "self/sender=1/receivers=2", msg: t1, sender: 1, receivers: []hotstuff.ID{1, 2}, want: []pendingMessage{{t1, 1, 2}}},
+		{name: "self/sender=1/receivers=3", msg: t1, sender: 1, receivers: []hotstuff.ID{1, 2, 3}, want: []pendingMessage{{t1, 1, 2}, {t1, 1, 3}}},
+		{name: "self/sender=1/receivers=4", msg: t1, sender: 1, receivers: []hotstuff.ID{1, 2, 3, 4}, want: []pendingMessage{{t1, 1, 2}, {t1, 1, 3}, {t1, 1, 4}}},
+		{name: "self/sender=2/receivers=5", msg: t1, sender: 2, receivers: []hotstuff.ID{1, 2, 3, 4, 5}, want: []pendingMessage{{t1, 2, 1}, {t1, 2, 3}, {t1, 2, 4}, {t1, 2, 5}}},
+		{name: "self/sender=3/receivers=6", msg: t1, sender: 3, receivers: []hotstuff.ID{1, 2, 3, 4, 5, 6}, want: []pendingMessage{{t1, 3, 1}, {t1, 3, 2}, {t1, 3, 4}, {t1, 3, 5}, {t1, 3, 6}}},
+		{name: "self/sender=4/receivers=7", msg: t1, sender: 4, receivers: []hotstuff.ID{1, 2, 3, 4, 5, 6, 7}, want: []pendingMessage{{t1, 4, 1}, {t1, 4, 2}, {t1, 4, 3}, {t1, 4, 5}, {t1, 4, 6}, {t1, 4, 7}}},
+		{name: "self/sender=5/receivers=6", msg: t1, sender: 5, receivers: []hotstuff.ID{2, 3, 4, 5, 6, 7}, want: []pendingMessage{{t1, 5, 2}, {t1, 5, 3}, {t1, 5, 4}, {t1, 5, 6}, {t1, 5, 7}}},
+		{name: "self/sender=6/receivers=6", msg: t1, sender: 6, receivers: []hotstuff.ID{1, 3, 4, 5, 6, 7}, want: []pendingMessage{{t1, 6, 1}, {t1, 6, 3}, {t1, 6, 4}, {t1, 6, 5}, {t1, 6, 7}}},
+		{name: "self/sender=7/receivers=6", msg: t1, sender: 7, receivers: []hotstuff.ID{1, 2, 4, 5, 6, 7}, want: []pendingMessage{{t1, 7, 1}, {t1, 7, 2}, {t1, 7, 4}, {t1, 7, 5}, {t1, 7, 6}}},
+		// sender is not part of the receivers list.
+		{name: "no_self/sender=1/receivers=0", msg: t1, sender: 1, receivers: []hotstuff.ID{}, want: []pendingMessage{}},
+		{name: "no_self/sender=1/receivers=1", msg: t1, sender: 1, receivers: []hotstuff.ID{2}, want: []pendingMessage{{t1, 1, 2}}},
+		{name: "no_self/sender=1/receivers=2", msg: t1, sender: 1, receivers: []hotstuff.ID{2, 3}, want: []pendingMessage{{t1, 1, 2}, {t1, 1, 3}}},
+		{name: "no_self/sender=1/receivers=3", msg: t1, sender: 1, receivers: []hotstuff.ID{2, 3, 4}, want: []pendingMessage{{t1, 1, 2}, {t1, 1, 3}, {t1, 1, 4}}},
+		{name: "no_self/sender=2/receivers=4", msg: t1, sender: 2, receivers: []hotstuff.ID{1, 3, 4, 5}, want: []pendingMessage{{t1, 2, 1}, {t1, 2, 3}, {t1, 2, 4}, {t1, 2, 5}}},
+		{name: "no_self/sender=3/receivers=5", msg: t1, sender: 3, receivers: []hotstuff.ID{1, 2, 4, 5, 6}, want: []pendingMessage{{t1, 3, 1}, {t1, 3, 2}, {t1, 3, 4}, {t1, 3, 5}, {t1, 3, 6}}},
+		{name: "no_self/sender=4/receivers=6", msg: t1, sender: 4, receivers: []hotstuff.ID{1, 2, 3, 5, 6, 7}, want: []pendingMessage{{t1, 4, 1}, {t1, 4, 2}, {t1, 4, 3}, {t1, 4, 5}, {t1, 4, 6}, {t1, 4, 7}}},
+		{name: "no_self/sender=5/receivers=5", msg: t1, sender: 5, receivers: []hotstuff.ID{2, 3, 4, 6, 7}, want: []pendingMessage{{t1, 5, 2}, {t1, 5, 3}, {t1, 5, 4}, {t1, 5, 6}, {t1, 5, 7}}},
+		{name: "no_self/sender=6/receivers=5", msg: t1, sender: 6, receivers: []hotstuff.ID{1, 3, 4, 5, 7}, want: []pendingMessage{{t1, 6, 1}, {t1, 6, 3}, {t1, 6, 4}, {t1, 6, 5}, {t1, 6, 7}}},
+		{name: "no_self/sender=7/receivers=5", msg: t1, sender: 7, receivers: []hotstuff.ID{1, 2, 4, 5, 6}, want: []pendingMessage{{t1, 7, 1}, {t1, 7, 2}, {t1, 7, 4}, {t1, 7, 5}, {t1, 7, 6}}},
+	}
+	for b.Loop() {
+		for _, tt := range tests {
+			sender := senders[tt.sender-1]
+			sub, err := sender.Sub(tt.receivers)
+			if err != nil {
+				b.Fatalf("Failed to create subconfiguration: %v", err)
+			}
+			// using the Timeout call to broadcast to the subconfiguration.
+			sub.Timeout(tt.msg)
+			// needed to access network.pendingMessages
+			network = sub.(*emulatedSender).network
+			network.pendingMessages = nil // reset pending messages for the next test
+		}
+	}
+}
+
+func createNetwork(t testing.TB, numNodes int) (*Network, []*emulatedSender) {
 	t.Helper()
 	network := NewSimpleNetwork(numNodes)
 	// create 4 nodes without twins

--- a/twins/network_test.go
+++ b/twins/network_test.go
@@ -119,6 +119,7 @@ func TestNetworkSubConfigBroadcastMessage(t *testing.T) {
 }
 
 func createNetwork(t *testing.T, numNodes int) (*Network, []*emulatedSender) {
+	t.Helper()
 	network := NewSimpleNetwork(numNodes)
 	// create 4 nodes without twins
 	nodes, _ := assignNodeIDs(uint8(numNodes), 0)
@@ -136,7 +137,8 @@ func createNetwork(t *testing.T, numNodes int) (*Network, []*emulatedSender) {
 func checkAppendedMessages(t *testing.T, name string, netMessages, want []pendingMessage) {
 	t.Helper()
 	if len(netMessages) < len(want) {
-		t.Fatalf("%s: got %d network messages, want at least %d", name, len(netMessages), len(want))
+		t.Errorf("%s: got %d network messages, want at least %d", name, len(netMessages), len(want))
+		return
 	}
 	// only last len(want) network messages are relevant for this test
 	got := slices.Clone(netMessages[len(netMessages)-len(want):])
@@ -157,6 +159,7 @@ func checkAppendedMessages(t *testing.T, name string, netMessages, want []pendin
 }
 
 func checkAllMessages(t *testing.T, got []pendingMessage, want []pendingMessage) {
+	t.Helper()
 	// Sort the got pending messages for comparison with the want pending messages.
 	// This is necessary because broadcasting message iterates over the receivers
 	// in a random order, since they are stored in a map (receivers=network.replicas).

--- a/twins/network_test.go
+++ b/twins/network_test.go
@@ -1,0 +1,209 @@
+package twins
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/relab/hotstuff"
+	"github.com/relab/hotstuff/protocol/rules/chainedhotstuff"
+)
+
+func TestNetworkSendMessage(t *testing.T) {
+	network, senders := createNetwork(t, 4)
+
+	tests := []struct {
+		msg      string
+		sender   hotstuff.ID
+		receiver hotstuff.ID
+		want     pendingMessage
+	}{
+		{msg: "s1r2", sender: 1, receiver: 2, want: pendingMessage{"s1r2", 1, 2}},
+		{msg: "s1r3", sender: 1, receiver: 3, want: pendingMessage{"s1r3", 1, 3}},
+		{msg: "s1r4", sender: 1, receiver: 4, want: pendingMessage{"s1r4", 1, 4}},
+		{msg: "s2r1", sender: 2, receiver: 1, want: pendingMessage{"s2r1", 2, 1}},
+		{msg: "s2r3", sender: 2, receiver: 3, want: pendingMessage{"s2r3", 2, 3}},
+		{msg: "s2r4", sender: 2, receiver: 4, want: pendingMessage{"s2r4", 2, 4}},
+		{msg: "s3r1", sender: 3, receiver: 1, want: pendingMessage{"s3r1", 3, 1}},
+		{msg: "s3r2", sender: 3, receiver: 2, want: pendingMessage{"s3r2", 3, 2}},
+		{msg: "s3r4", sender: 3, receiver: 4, want: pendingMessage{"s3r4", 3, 4}},
+		{msg: "s4r1", sender: 4, receiver: 1, want: pendingMessage{"s4r1", 4, 1}},
+		{msg: "s4r2", sender: 4, receiver: 2, want: pendingMessage{"s4r2", 4, 2}},
+		{msg: "s4r3", sender: 4, receiver: 3, want: pendingMessage{"s4r3", 4, 3}},
+	}
+	var wantPendingMessages []pendingMessage
+	for _, tt := range tests {
+		sender := senders[tt.sender-1]
+		sender.sendMessage(tt.receiver, tt.msg)
+		checkAppendedMessages(t, tt.msg, network.pendingMessages, []pendingMessage{tt.want})
+		wantPendingMessages = append(wantPendingMessages, tt.want)
+	}
+
+	gotPendingMessages := slices.Clone(network.pendingMessages)
+	checkAllMessages(t, gotPendingMessages, wantPendingMessages)
+}
+
+func TestNetworkBroadcastMessage(t *testing.T) {
+	network, senders := createNetwork(t, 4)
+
+	tests := []struct {
+		msg    string
+		sender hotstuff.ID
+		want   []pendingMessage
+	}{
+		{msg: "s1", sender: 1, want: []pendingMessage{{"s1", 1, 2}, {"s1", 1, 3}, {"s1", 1, 4}}}, // receivers: {2, 3, 4}
+		{msg: "s2", sender: 2, want: []pendingMessage{{"s2", 2, 1}, {"s2", 2, 3}, {"s2", 2, 4}}}, // receivers: {1, 3, 4}
+		{msg: "s3", sender: 3, want: []pendingMessage{{"s3", 3, 1}, {"s3", 3, 2}, {"s3", 3, 4}}}, // receivers: {1, 2, 4}
+		{msg: "s4", sender: 4, want: []pendingMessage{{"s4", 4, 1}, {"s4", 4, 2}, {"s4", 4, 3}}}, // receivers: {1, 2, 3}
+	}
+	var wantPendingMessages []pendingMessage
+	for _, tt := range tests {
+		sender := senders[tt.sender-1]
+		sender.broadcastMessage(tt.msg)
+		checkAppendedMessages(t, tt.msg, network.pendingMessages, tt.want)
+		wantPendingMessages = append(wantPendingMessages, tt.want...)
+	}
+
+	gotPendingMessages := slices.Clone(network.pendingMessages)
+	checkAllMessages(t, gotPendingMessages, wantPendingMessages)
+}
+
+func TestNetworkSubConfigBroadcastMessage(t *testing.T) {
+	network, senders := createNetwork(t, 7)
+
+	t1 := hotstuff.TimeoutMsg{ID: 1, View: 1}
+	tests := []struct {
+		name      string
+		msg       hotstuff.TimeoutMsg
+		sender    hotstuff.ID
+		receivers []hotstuff.ID
+		want      []pendingMessage
+	}{
+		// sender is also part of the receivers list, but it will not send to itself.
+		{name: "self/sender=1/receivers=1", msg: t1, sender: 1, receivers: []hotstuff.ID{1}, want: []pendingMessage{}},
+		{name: "self/sender=1/receivers=2", msg: t1, sender: 1, receivers: []hotstuff.ID{1, 2}, want: []pendingMessage{{t1, 1, 2}}},
+		{name: "self/sender=1/receivers=3", msg: t1, sender: 1, receivers: []hotstuff.ID{1, 2, 3}, want: []pendingMessage{{t1, 1, 2}, {t1, 1, 3}}},
+		{name: "self/sender=1/receivers=4", msg: t1, sender: 1, receivers: []hotstuff.ID{1, 2, 3, 4}, want: []pendingMessage{{t1, 1, 2}, {t1, 1, 3}, {t1, 1, 4}}},
+		{name: "self/sender=2/receivers=5", msg: t1, sender: 2, receivers: []hotstuff.ID{1, 2, 3, 4, 5}, want: []pendingMessage{{t1, 2, 1}, {t1, 2, 3}, {t1, 2, 4}, {t1, 2, 5}}},
+		{name: "self/sender=3/receivers=6", msg: t1, sender: 3, receivers: []hotstuff.ID{1, 2, 3, 4, 5, 6}, want: []pendingMessage{{t1, 3, 1}, {t1, 3, 2}, {t1, 3, 4}, {t1, 3, 5}, {t1, 3, 6}}},
+		{name: "self/sender=4/receivers=7", msg: t1, sender: 4, receivers: []hotstuff.ID{1, 2, 3, 4, 5, 6, 7}, want: []pendingMessage{{t1, 4, 1}, {t1, 4, 2}, {t1, 4, 3}, {t1, 4, 5}, {t1, 4, 6}, {t1, 4, 7}}},
+		{name: "self/sender=5/receivers=6", msg: t1, sender: 5, receivers: []hotstuff.ID{2, 3, 4, 5, 6, 7}, want: []pendingMessage{{t1, 5, 2}, {t1, 5, 3}, {t1, 5, 4}, {t1, 5, 6}, {t1, 5, 7}}},
+		{name: "self/sender=6/receivers=6", msg: t1, sender: 6, receivers: []hotstuff.ID{1, 3, 4, 5, 6, 7}, want: []pendingMessage{{t1, 6, 1}, {t1, 6, 3}, {t1, 6, 4}, {t1, 6, 5}, {t1, 6, 7}}},
+		{name: "self/sender=7/receivers=6", msg: t1, sender: 7, receivers: []hotstuff.ID{1, 2, 4, 5, 6, 7}, want: []pendingMessage{{t1, 7, 1}, {t1, 7, 2}, {t1, 7, 4}, {t1, 7, 5}, {t1, 7, 6}}},
+		// sender is not part of the receivers list.
+		{name: "no_self/sender=1/receivers=0", msg: t1, sender: 1, receivers: []hotstuff.ID{}, want: []pendingMessage{}},
+		{name: "no_self/sender=1/receivers=1", msg: t1, sender: 1, receivers: []hotstuff.ID{2}, want: []pendingMessage{{t1, 1, 2}}},
+		{name: "no_self/sender=1/receivers=2", msg: t1, sender: 1, receivers: []hotstuff.ID{2, 3}, want: []pendingMessage{{t1, 1, 2}, {t1, 1, 3}}},
+		{name: "no_self/sender=1/receivers=3", msg: t1, sender: 1, receivers: []hotstuff.ID{2, 3, 4}, want: []pendingMessage{{t1, 1, 2}, {t1, 1, 3}, {t1, 1, 4}}},
+		{name: "no_self/sender=2/receivers=4", msg: t1, sender: 2, receivers: []hotstuff.ID{1, 3, 4, 5}, want: []pendingMessage{{t1, 2, 1}, {t1, 2, 3}, {t1, 2, 4}, {t1, 2, 5}}},
+		{name: "no_self/sender=3/receivers=5", msg: t1, sender: 3, receivers: []hotstuff.ID{1, 2, 4, 5, 6}, want: []pendingMessage{{t1, 3, 1}, {t1, 3, 2}, {t1, 3, 4}, {t1, 3, 5}, {t1, 3, 6}}},
+		{name: "no_self/sender=4/receivers=6", msg: t1, sender: 4, receivers: []hotstuff.ID{1, 2, 3, 5, 6, 7}, want: []pendingMessage{{t1, 4, 1}, {t1, 4, 2}, {t1, 4, 3}, {t1, 4, 5}, {t1, 4, 6}, {t1, 4, 7}}},
+		{name: "no_self/sender=5/receivers=5", msg: t1, sender: 5, receivers: []hotstuff.ID{2, 3, 4, 6, 7}, want: []pendingMessage{{t1, 5, 2}, {t1, 5, 3}, {t1, 5, 4}, {t1, 5, 6}, {t1, 5, 7}}},
+		{name: "no_self/sender=6/receivers=5", msg: t1, sender: 6, receivers: []hotstuff.ID{1, 3, 4, 5, 7}, want: []pendingMessage{{t1, 6, 1}, {t1, 6, 3}, {t1, 6, 4}, {t1, 6, 5}, {t1, 6, 7}}},
+		{name: "no_self/sender=7/receivers=5", msg: t1, sender: 7, receivers: []hotstuff.ID{1, 2, 4, 5, 6}, want: []pendingMessage{{t1, 7, 1}, {t1, 7, 2}, {t1, 7, 4}, {t1, 7, 5}, {t1, 7, 6}}},
+	}
+	var wantPendingMessages []pendingMessage
+	for _, tt := range tests {
+		sender := senders[tt.sender-1]
+		sub, err := sender.Sub(tt.receivers)
+		if err != nil {
+			t.Fatalf("Failed to create subconfiguration: %v", err)
+		}
+		// using the Timeout call to broadcast to the subconfiguration.
+		sub.Timeout(tt.msg)
+		checkAppendedMessages(t, tt.name, network.pendingMessages, tt.want)
+		wantPendingMessages = append(wantPendingMessages, tt.want...)
+	}
+
+	gotPendingMessages := slices.Clone(network.pendingMessages)
+	checkAllMessages(t, gotPendingMessages, wantPendingMessages)
+}
+
+func createNetwork(t *testing.T, numNodes int) (*Network, []*emulatedSender) {
+	network := NewSimpleNetwork(numNodes)
+	// create 4 nodes without twins
+	nodes, _ := assignNodeIDs(uint8(numNodes), 0)
+
+	if err := network.createTwinsNodes(nodes, chainedhotstuff.ModuleName); err != nil {
+		t.Fatalf("Failed to create nodes: %v", err)
+	}
+	senders := make([]*emulatedSender, len(network.nodes))
+	for i, node := range network.nodes {
+		senders[i-1] = network.NewSender(node)
+	}
+	return network, senders
+}
+
+func checkAppendedMessages(t *testing.T, name string, netMessages, want []pendingMessage) {
+	t.Helper()
+	if len(netMessages) < len(want) {
+		t.Fatalf("%s: got %d network messages, want at least %d", name, len(netMessages), len(want))
+	}
+	// only last len(want) network messages are relevant for this test
+	got := slices.Clone(netMessages[len(netMessages)-len(want):])
+	slices.SortFunc(got, func(a, b pendingMessage) int {
+		if a.sender != b.sender {
+			return int(a.sender) - int(b.sender)
+		}
+		if a.receiver != b.receiver {
+			return int(a.receiver) - int(b.receiver)
+		}
+		return 0
+	})
+	for i := range got {
+		if got[i].sender != want[i].sender || got[i].receiver != want[i].receiver || got[i].message != want[i].message {
+			t.Errorf("%s: pendingMessages[%d] = %v, want %v", name, i, got[i], want[i])
+		}
+	}
+}
+
+func checkAllMessages(t *testing.T, got []pendingMessage, want []pendingMessage) {
+	// Sort the got pending messages for comparison with the want pending messages.
+	// This is necessary because broadcasting message iterates over the receivers
+	// in a random order, since they are stored in a map (receivers=network.replicas).
+	slices.SortFunc(got, func(a, b pendingMessage) int {
+		if a.sender != b.sender {
+			return int(a.sender) - int(b.sender)
+		}
+		if a.receiver != b.receiver {
+			return int(a.receiver) - int(b.receiver)
+		}
+		return 0
+	})
+	// Sort the want pending messages for comparison with the got pending messages.
+	// This is necessary because the want pending messages are created in a specific order,
+	// which is not guaranteed to be the same as the order as the sorted got pending messages
+	// when there are repeated sender-receiver pairs.
+	slices.SortFunc(want, func(a, b pendingMessage) int {
+		if a.sender != b.sender {
+			return int(a.sender) - int(b.sender)
+		}
+		if a.receiver != b.receiver {
+			return int(a.receiver) - int(b.receiver)
+		}
+		return 0
+	})
+
+	for i := range max(len(got), len(want)) {
+		if i >= len(got) {
+			t.Errorf("pendingMessages[%d] = none, want: %v", i, want[i])
+			continue
+		}
+		if i >= len(want) {
+			t.Errorf("pendingMessages[%d] = %v, want none", i, got[i])
+			continue
+		}
+		if got[i].sender != want[i].sender || got[i].receiver != want[i].receiver || got[i].message != want[i].message {
+			t.Errorf("pendingMessages[%d] = %v, want %v", i, got[i], want[i])
+		}
+	}
+
+	if t.Failed() {
+		// ignore message content for log clarity
+		for i := range got {
+			got[i].message = nil
+			want[i].message = nil
+		}
+		t.Logf("pendingMessages:  got %v", got)
+		t.Logf("pendingMessages: want %v", want)
+	}
+}

--- a/twins/node.go
+++ b/twins/node.go
@@ -1,0 +1,138 @@
+package twins
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/relab/hotstuff"
+	"github.com/relab/hotstuff/core"
+	"github.com/relab/hotstuff/core/eventloop"
+	"github.com/relab/hotstuff/core/logging"
+	"github.com/relab/hotstuff/internal/proto/clientpb"
+	"github.com/relab/hotstuff/modules"
+	"github.com/relab/hotstuff/protocol"
+	"github.com/relab/hotstuff/protocol/consensus"
+	"github.com/relab/hotstuff/protocol/disagg/clique"
+	"github.com/relab/hotstuff/protocol/synchronizer"
+	"github.com/relab/hotstuff/protocol/synchronizer/viewduration"
+	"github.com/relab/hotstuff/protocol/votingmachine"
+	"github.com/relab/hotstuff/security/blockchain"
+	"github.com/relab/hotstuff/security/cert"
+	"github.com/relab/hotstuff/security/crypto/ecdsa"
+	"github.com/relab/hotstuff/security/crypto/keygen"
+	"github.com/relab/hotstuff/wiring"
+)
+
+type node struct {
+	config         *core.RuntimeConfig
+	logger         logging.Logger
+	sender         *emulatedSender
+	blockchain     *blockchain.Blockchain
+	commandCache   *clientpb.CommandCache
+	voter          *consensus.Voter
+	proposer       *consensus.Proposer
+	eventLoop      *eventloop.EventLoop
+	viewStates     *protocol.ViewStates
+	leaderRotation modules.LeaderRotation
+	synchronizer   *synchronizer.Synchronizer
+	timeoutManager *timeoutManager
+
+	id             NodeID
+	executedBlocks []*hotstuff.Block
+	effectiveView  hotstuff.View
+	log            strings.Builder
+}
+
+func newNode(n *Network, nodeID NodeID, consensusName string) (*node, error) {
+	cryptoName := ecdsa.ModuleName
+	pk, err := keygen.GenerateECDSAPrivateKey()
+	if err != nil {
+		return nil, err
+	}
+	node := &node{
+		id:           nodeID,
+		config:       core.NewRuntimeConfig(nodeID.ReplicaID, pk, core.WithSyncVerification()),
+		commandCache: clientpb.NewCommandCache(1),
+	}
+	node.logger = logging.NewWithDest(&node.log, fmt.Sprintf("r%dn%d", nodeID.ReplicaID, nodeID.NetworkID))
+	node.eventLoop = eventloop.New(node.logger, 100)
+	node.sender = newSender(n, node)
+	depsSecurity, err := wiring.NewSecurity(
+		node.eventLoop,
+		node.logger,
+		node.config,
+		node.sender,
+		cryptoName,
+		cert.WithCache(100),
+	)
+	if err != nil {
+		return nil, err
+	}
+	node.blockchain = depsSecurity.BlockChain()
+	consensusRules, err := wiring.NewConsensusRules(node.logger, node.config, node.blockchain, consensusName)
+	if err != nil {
+		return nil, err
+	}
+	node.viewStates, err = protocol.NewViewStates(node.blockchain, depsSecurity.Authority())
+	if err != nil {
+		return nil, err
+	}
+	committer := consensus.NewCommitter(node.eventLoop, node.logger, node.blockchain, node.viewStates, consensusRules)
+	node.leaderRotation = leaderRotation(n.views)
+	votingMachine := votingmachine.New(
+		node.logger,
+		node.eventLoop,
+		node.config,
+		depsSecurity.BlockChain(),
+		depsSecurity.Authority(),
+		node.viewStates,
+	)
+	disAgg := clique.New(
+		node.config,
+		votingMachine,
+		node.leaderRotation,
+		node.sender,
+	)
+	node.voter = consensus.NewVoter(
+		node.config,
+		node.leaderRotation,
+		consensusRules,
+		disAgg,
+		depsSecurity.Authority(),
+		committer,
+	)
+	node.proposer = consensus.NewProposer(
+		node.eventLoop,
+		node.config,
+		node.blockchain,
+		disAgg,
+		node.voter,
+		node.commandCache,
+		committer,
+	)
+	node.synchronizer = synchronizer.New(
+		node.eventLoop,
+		node.logger,
+		node.config,
+		depsSecurity.Authority(),
+		node.leaderRotation,
+		viewduration.NewFixed(100*time.Millisecond),
+		node.proposer,
+		node.voter,
+		node.viewStates,
+		node.sender,
+	)
+	node.timeoutManager = newTimeoutManager(n, node, node.eventLoop, node.viewStates)
+	// necessary to count executed commands.
+	node.eventLoop.RegisterHandler(hotstuff.CommitEvent{}, func(event any) {
+		commit := event.(hotstuff.CommitEvent)
+		node.executedBlocks = append(node.executedBlocks, commit.Block)
+	})
+	commandGenerator := &commandGenerator{}
+	for range n.views {
+		cmd := commandGenerator.next()
+		node.commandCache.Add(cmd)
+	}
+	return node, nil
+}

--- a/twins/sender.go
+++ b/twins/sender.go
@@ -1,0 +1,130 @@
+package twins
+
+import (
+	"context"
+	"fmt"
+	"slices"
+
+	"github.com/relab/hotstuff"
+	"github.com/relab/hotstuff/modules"
+)
+
+type emulatedSender struct {
+	node      *node
+	network   *Network
+	subConfig []hotstuff.ID
+}
+
+// newSender returns a new emulated sender based on the node and network.
+func newSender(n *Network, node *node) *emulatedSender {
+	return &emulatedSender{
+		network: n,
+		node:    node,
+	}
+}
+
+// broadcastMessage invokes sendMessage for all replicas in the configuration.
+func (s *emulatedSender) broadcastMessage(message any) {
+	for id := range s.network.replicas {
+		if id == s.node.id.ReplicaID {
+			// do not send message to self or twin
+			continue
+		} else if len(s.subConfig) == 0 || slices.Contains(s.subConfig, id) {
+			s.sendMessage(id, message)
+		}
+	}
+}
+
+// sendMessage adds a message to the queue in the emulated network. The message is sent
+// to the replica in the next tick.
+// NOTE: shouldDrop is called to check if the message should be dropped before sending.
+func (s *emulatedSender) sendMessage(id hotstuff.ID, message any) {
+	nodes, ok := s.network.replicas[id]
+	if !ok {
+		panic(fmt.Errorf("attempt to send message to unknown replica %d", id))
+	}
+	for _, node := range nodes {
+		if s.shouldDrop(node.id, message) {
+			s.network.logger.Infof("node %v -> node %v: DROP %T(%v)", s.node.id, node.id, message, message)
+			continue
+		}
+		s.network.logger.Infof("node %v -> node %v: SEND %T(%v)", s.node.id, node.id, message, message)
+		s.network.pendingMessages = append(
+			s.network.pendingMessages,
+			pendingMessage{
+				sender:   uint32(s.node.id.NetworkID),
+				receiver: uint32(node.id.NetworkID),
+				message:  message,
+			},
+		)
+	}
+}
+
+// shouldDrop checks if a message to the node identified by id should be dropped.
+func (s *emulatedSender) shouldDrop(id NodeID, message any) bool {
+	// retrieve the drop config for this node.
+	return s.network.shouldDrop(s.node.id.NetworkID, id.NetworkID, message)
+}
+
+// Sub returns a subconfiguration containing the replicas specified in the ids slice.
+func (s *emulatedSender) Sub(ids []hotstuff.ID) (sub modules.Sender, err error) {
+	return &emulatedSender{
+		node:      s.node,
+		network:   s.network,
+		subConfig: ids,
+	}, nil
+}
+
+// Propose sends the block to all replicas in the configuration.
+func (s *emulatedSender) Propose(proposal *hotstuff.ProposeMsg) {
+	// very important to dereference it!
+	s.broadcastMessage(*proposal)
+}
+
+// Timeout sends the timeout message to all replicas.
+func (s *emulatedSender) Timeout(msg hotstuff.TimeoutMsg) {
+	s.broadcastMessage(msg)
+}
+
+// Vote sends the partial cert to the replica.
+func (s *emulatedSender) Vote(id hotstuff.ID, cert hotstuff.PartialCert) error {
+	if _, ok := s.network.replicas[id]; !ok {
+		return fmt.Errorf("replica with id %d not found", id)
+	}
+	s.sendMessage(id, hotstuff.VoteMsg{
+		ID:          s.node.id.ReplicaID,
+		PartialCert: cert,
+	})
+	return nil
+}
+
+// NewView sends the new view message to the replica.
+func (s *emulatedSender) NewView(id hotstuff.ID, si hotstuff.SyncInfo) error {
+	if _, ok := s.network.replicas[id]; !ok {
+		return fmt.Errorf("replica with id %d not found", id)
+	}
+	s.sendMessage(id, hotstuff.NewViewMsg{
+		ID:          s.node.id.ReplicaID,
+		SyncInfo:    si,
+		FromNetwork: true,
+	})
+	return nil
+}
+
+// RequestBlock requests a block from all the replicas in the network.
+func (s *emulatedSender) RequestBlock(_ context.Context, hash hotstuff.Hash) (block *hotstuff.Block, ok bool) {
+	for _, replica := range s.network.replicas {
+		for _, node := range replica {
+			if s.shouldDrop(node.id, hash) {
+				continue
+			}
+			block, ok = node.blockchain.LocalGet(hash)
+			if ok {
+				return block, true
+			}
+		}
+	}
+	return nil, false
+}
+
+var _ modules.Sender = (*emulatedSender)(nil)

--- a/twins/timeoutmgr.go
+++ b/twins/timeoutmgr.go
@@ -1,0 +1,61 @@
+package twins
+
+import (
+	"github.com/relab/hotstuff"
+	"github.com/relab/hotstuff/core/eventloop"
+	"github.com/relab/hotstuff/protocol"
+)
+
+type timeoutManager struct {
+	eventLoop  *eventloop.EventLoop
+	viewStates *protocol.ViewStates
+
+	node      *node
+	network   *Network
+	countdown int
+	timeout   int
+}
+
+func (tm *timeoutManager) advance() {
+	tm.countdown--
+	if tm.countdown == 0 {
+		view := tm.viewStates.View()
+		tm.eventLoop.AddEvent(hotstuff.TimeoutEvent{View: view})
+		tm.countdown = tm.timeout
+		if tm.node.effectiveView <= view {
+			tm.node.effectiveView = view + 1
+			tm.network.logger.Infof("node %v effective view is %d due to timeout", tm.node.id, tm.node.effectiveView)
+		}
+	}
+}
+
+func (tm *timeoutManager) viewChange(event hotstuff.ViewChangeEvent) {
+	tm.countdown = tm.timeout
+	if event.Timeout {
+		tm.network.logger.Infof("node %v entered view %d after timeout", tm.node.id, event.View)
+	} else {
+		tm.network.logger.Infof("node %v entered view %d after voting", tm.node.id, event.View)
+	}
+}
+
+func newTimeoutManager(
+	network *Network,
+	node *node,
+	eventLoop *eventloop.EventLoop,
+	viewStates *protocol.ViewStates,
+) *timeoutManager {
+	tm := &timeoutManager{
+		node:       node,
+		network:    network,
+		eventLoop:  eventLoop,
+		viewStates: viewStates,
+		timeout:    5,
+	}
+	tm.eventLoop.RegisterHandler(tick{}, func(_ any) {
+		tm.advance()
+	}, eventloop.Prioritize())
+	tm.eventLoop.RegisterHandler(hotstuff.ViewChangeEvent{}, func(event any) {
+		tm.viewChange(event.(hotstuff.ViewChangeEvent))
+	}, eventloop.Prioritize())
+	return tm
+}

--- a/twins/twins_test.go
+++ b/twins/twins_test.go
@@ -5,7 +5,7 @@ import (
 	"time"
 
 	"github.com/relab/hotstuff/core/logging"
-	_ "github.com/relab/hotstuff/protocol/rules/chainedhotstuff"
+	"github.com/relab/hotstuff/protocol/rules/chainedhotstuff"
 	"github.com/relab/hotstuff/twins"
 )
 
@@ -32,7 +32,7 @@ func TestTwins(t *testing.T) {
 		if err != nil {
 			break
 		}
-		result, err := twins.ExecuteScenario(s, numNodes, numTwins, 100, "chainedhotstuff")
+		result, err := twins.ExecuteScenario(s, numNodes, numTwins, 100, chainedhotstuff.ModuleName)
 		if err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
This adds tests the following tests and benchmarks:

- TestNetworkSendMessage
- TestNetworkBroadcastMessage
- TestNetworkSubConfigBroadcastMessage
- BenchmarkNetworkSubConfigBroadcastMessage

The goal of this PR was mainly to replace the hotstuff.IDSet from the twins package, but to do so, and make sure I didn't mess things up, I also added the tests above. Much more effort than I had planned. But now it is there.

