### PR TITLE
Add support for cue-based experiment configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,11 +8,11 @@
 # Test binary, built with `go test -c`
 *.test
 
-# Output of the go coverage tool, specifically when used with LiteIDE
+# Output of the go coverage tool
 *.out
 
-# Dependency directories (remove the comment below to include it)
-# vendor/
+# Test output
+*.log
 
 # delve debug binary
 __debug_bin

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -25,6 +25,9 @@
 	"go.testFlags": [
 		"-count=1"
 	],
+	"gopls": {
+		"ui.semanticTokens": true
+	},
 	"cSpell.enabled": true,
 	"cSpell.ignorePaths": [
 		"package-lock.json",

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ tools: download
 	go install tool
 
 test:
-	@go test ./...
+	@go test -v ./... > test.log
 
 short:
 	@go test -short ./...

--- a/cmd/plot/main.go
+++ b/cmd/plot/main.go
@@ -8,9 +8,7 @@ import (
 	"os"
 	"time"
 
-	_ "github.com/relab/hotstuff/internal/proto/orchestrationpb"
 	"github.com/relab/hotstuff/metrics/plotting"
-	_ "github.com/relab/hotstuff/metrics/types"
 )
 
 var (

--- a/internal/config/cue_test.go
+++ b/internal/config/cue_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/relab/hotstuff/internal/config"
 )
 
-func TestLoad(t *testing.T) {
+func TestNewCue(t *testing.T) {
 	replicaHosts := []string{"bbchain1", "bbchain2", "bbchain3", "bbchain4", "bbchain5", "bbchain6"}
 	clientHosts := []string{"bbchain7", "bbchain8"}
 	locations := []string{"Melbourne", "Toronto", "Prague", "Paris", "Tokyo", "Amsterdam", "Auckland", "Moscow", "Stockholm", "London"}
@@ -73,6 +73,20 @@ func TestLoad(t *testing.T) {
 		Replicas:     3,
 		Clients:      2,
 	}
+	exp := &config.ExperimentConfig{
+		ReplicaHosts:      []string{"localhost"},
+		ClientHosts:       []string{"localhost"},
+		Replicas:          4,
+		Clients:           1,
+		Locations:         []string{"Rome", "Oslo", "London", "Munich"},
+		TreePositions:     []uint32{3, 2, 1, 4},
+		BranchFactor:      2,
+		Consensus:         "chainedhotstuff",
+		Communication:     "clique",
+		Crypto:            "ecdsa",
+		LeaderRotation:    "round-robin",
+		ByzantineStrategy: map[string][]uint32{"": {}},
+	}
 	tests := []struct {
 		name     string
 		filename string
@@ -89,16 +103,98 @@ func TestLoad(t *testing.T) {
 		{name: "InvalidLocationsSize", filename: "invalid-loc-size.cue", wantCfg: nil, wantErr: true},
 		{name: "InvalidTree", filename: "invalid-tree.cue", wantCfg: nil, wantErr: true},
 		{name: "Invalid2TreeOnly", filename: "invalid-tree-only.cue", wantCfg: nil, wantErr: true},
+		{name: "Experiments", filename: "exp.cue", wantCfg: exp, wantErr: false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			gotCfg, err := config.NewCue(filepath.Join("testdata", tt.filename), nil)
 			if (err != nil) != tt.wantErr {
-				t.Errorf("Load(%s) error = %v, wantErr %v", tt.filename, err, tt.wantErr)
+				t.Errorf("NewCue(%s) error = %v, wantErr %v", tt.filename, err, tt.wantErr)
 				return
 			}
-			if diff := cmp.Diff(gotCfg, tt.wantCfg); diff != "" {
-				t.Errorf("Load(%s) mismatch (-want +got):\n%s", tt.filename, diff)
+			if diff := cmp.Diff(tt.wantCfg, gotCfg); diff != "" {
+				t.Errorf("NewCue(%s) mismatch (-want +got):\n%s", tt.filename, diff)
+			}
+		})
+	}
+}
+
+func TestNewCueExperiment(t *testing.T) {
+	fourExp := []*config.ExperimentConfig{
+		{
+			ReplicaHosts:      []string{"localhost"},
+			ClientHosts:       []string{"localhost"},
+			Replicas:          4,
+			Clients:           1,
+			Locations:         []string{"Rome", "Oslo", "London", "Munich"},
+			TreePositions:     []uint32{3, 2, 1, 4},
+			BranchFactor:      2,
+			Consensus:         "chainedhotstuff",
+			Communication:     "clique",
+			Crypto:            "ecdsa",
+			LeaderRotation:    "round-robin",
+			ByzantineStrategy: map[string][]uint32{"": {}},
+		},
+		{
+			ReplicaHosts:      []string{"localhost"},
+			ClientHosts:       []string{"localhost"},
+			Replicas:          4,
+			Clients:           1,
+			Locations:         []string{"Rome", "Oslo", "London", "Munich"},
+			TreePositions:     []uint32{3, 2, 1, 4},
+			BranchFactor:      2,
+			Consensus:         "simplehotstuff",
+			Communication:     "clique",
+			Crypto:            "ecdsa",
+			LeaderRotation:    "round-robin",
+			ByzantineStrategy: map[string][]uint32{"fork": {2}},
+		},
+		{
+			ReplicaHosts:      []string{"localhost"},
+			ClientHosts:       []string{"localhost"},
+			Replicas:          4,
+			Clients:           1,
+			Locations:         []string{"Rome", "Oslo", "London", "Munich"},
+			TreePositions:     []uint32{3, 2, 1, 4},
+			BranchFactor:      2,
+			Consensus:         "fasthotstuff",
+			Communication:     "kauri",
+			Crypto:            "ecdsa",
+			LeaderRotation:    "round-robin",
+			ByzantineStrategy: map[string][]uint32{"silence": {2}},
+		},
+		{
+			ReplicaHosts:      []string{"localhost"},
+			ClientHosts:       []string{"localhost"},
+			Replicas:          4,
+			Clients:           1,
+			Locations:         []string{"Rome", "Oslo", "London", "Munich"},
+			TreePositions:     []uint32{3, 2, 1, 4},
+			BranchFactor:      2,
+			Consensus:         "chainedhotstuff",
+			Communication:     "kauri",
+			Crypto:            "ecdsa",
+			LeaderRotation:    "round-robin",
+			ByzantineStrategy: map[string][]uint32{"": {}},
+		},
+	}
+	tests := []struct {
+		name     string
+		filename string
+		wantCfg  []*config.ExperimentConfig
+		wantErr  bool
+	}{
+		{name: "FourExperiments", filename: "four-experiments.cue", wantCfg: fourExp, wantErr: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotCfg, err := config.NewCueExperiments(filepath.Join("testdata", tt.filename))
+			if (err != nil) != tt.wantErr {
+				t.Errorf("NewCueExperiments(%s) error = %v, wantErr %v", tt.filename, err, tt.wantErr)
+				return
+			}
+			if diff := cmp.Diff(tt.wantCfg, gotCfg); diff != "" {
+				t.Errorf("NewCueExperiments(%s) mismatch (-want +got):\n%s", tt.filename, diff)
 			}
 		})
 	}

--- a/internal/config/cue_test.go
+++ b/internal/config/cue_test.go
@@ -182,16 +182,24 @@ func TestNewCueExperiment(t *testing.T) {
 		name     string
 		filename string
 		wantCfg  []*config.ExperimentConfig
+		wantLen  int
 		wantErr  bool
 	}{
-		{name: "FourExperiments", filename: "four-experiments.cue", wantCfg: fourExp, wantErr: false},
+		{name: "FourExperiments", filename: "four-experiments.cue", wantCfg: fourExp, wantLen: 4, wantErr: false},
+		{name: "SweepExperiments", filename: "sweep-experiments.cue", wantLen: 16, wantErr: false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			gotCfg, err := config.NewCueExperiments(filepath.Join("testdata", tt.filename))
 			if (err != nil) != tt.wantErr {
-				t.Errorf("NewCueExperiments(%s) error = %v, wantErr %v", tt.filename, err, tt.wantErr)
+				t.Errorf("NewCueExperiments(%s) error = %v, want %v", tt.filename, err, tt.wantErr)
 				return
+			}
+			if len(gotCfg) != tt.wantLen {
+				t.Errorf("NewCueExperiments(%s) length = %d, want %d", tt.filename, len(gotCfg), tt.wantLen)
+			}
+			if tt.wantCfg == nil {
+				return // skip diff check for large parameter sweeps
 			}
 			if diff := cmp.Diff(tt.wantCfg, gotCfg); diff != "" {
 				t.Errorf("NewCueExperiments(%s) mismatch (-want +got):\n%s", tt.filename, diff)

--- a/internal/config/exp-config.cue
+++ b/internal/config/exp-config.cue
@@ -1,0 +1,48 @@
+package config
+
+// This file defines a configuration for running experiments with different parameters.
+// Use the following command to generate the `experiments.cue` file:
+//   cue eval --out cue -e config.experiments exp-config.cue > experiments.cue
+config: {
+	// Shared static settings
+	shared: {
+		replicaHosts: ["localhost"]
+		clientHosts: ["localhost"]
+		replicas: 4
+		clients:  1
+		locations: ["Rome", "Oslo", "London", "Munich"]
+		treePositions: [3, 2, 1, 4]
+		branchFactor: 2
+	}
+
+	// Parameter sweeps
+	params: {
+		consensus: ["chainedhotstuff", "simplehotstuff", "fasthotstuff"]
+		leaderRotation: ["round-robin", "fixed", "carousel", "reputation"]
+		crypto: ["ecdsa", "eddsa", "bls12"]
+		communication: ["clique", "kauri"]
+		byz: [
+			{strategy: "", targets: []},
+			{strategy: "fork", targets: [2]},
+			{strategy: "silence", targets: [2]},
+		]
+	}
+
+	// Cross-product into experiments
+	experiments: [
+		for cs in params.consensus
+		for ld in params.leaderRotation
+		for cr in params.crypto
+		for cm in params.communication
+		for bc in params.byz {
+			config: {
+				shared
+				consensus:      cs
+				leaderRotation: ld
+				crypto:         cr
+				communication:  cm
+				byzantineStrategy: {(bc.strategy): bc.targets}
+			}
+		},
+	]
+}

--- a/internal/config/schema.cue
+++ b/internal/config/schema.cue
@@ -31,6 +31,15 @@ config: {
 		branchFactor!: int & >1 & <=div(replicas, 2)
 	}
 
+	// Consensus algorithm to use. (Default: "chainedhotstuff")
+	consensus: *"chainedhotstuff" | "simplehotstuff" | "fasthotstuff"
+	// Leader rotation strategy to use. (Default: "round-robin")
+	leaderRotation: *"round-robin" | "fixed" | "carousel" | "reputation"
+	// Cryptographic algorithm to use. (Default: "ecdsa")
+	crypto: *"ecdsa" | "eddsa" | "bls12"
+	// Communication protocol to use. (Default: "clique")
+	communication: *"clique" | "kauri"
+
 	// Byzantine strategy for different replicas (optional).
 	byzantineStrategy?: {
 		silent?: [...int & >=1 & <=replicas]

--- a/internal/config/testdata/exp.cue
+++ b/internal/config/testdata/exp.cue
@@ -1,0 +1,16 @@
+config: {
+	consensus:      "chainedhotstuff"
+	leaderRotation: "round-robin"
+	crypto:         "ecdsa"
+	communication:  "clique"
+	byzantineStrategy: {
+		"": []
+	}
+	replicaHosts: ["localhost"]
+	clientHosts: ["localhost"]
+	replicas: 4
+	clients:  1
+	locations: ["Rome", "Oslo", "London", "Munich"]
+	treePositions: [3, 2, 1, 4]
+	branchFactor: 2
+}

--- a/internal/config/testdata/four-experiments.cue
+++ b/internal/config/testdata/four-experiments.cue
@@ -1,0 +1,69 @@
+[{
+	config: {
+		consensus:      "chainedhotstuff"
+		leaderRotation: "round-robin"
+		crypto:         "ecdsa"
+		communication:  "clique"
+		byzantineStrategy: {
+			"": []
+		}
+		replicaHosts: ["localhost"]
+		clientHosts: ["localhost"]
+		replicas: 4
+		clients:  1
+		locations: ["Rome", "Oslo", "London", "Munich"]
+		treePositions: [3, 2, 1, 4]
+		branchFactor: 2
+	}
+}, {
+	config: {
+		consensus:      "simplehotstuff"
+		leaderRotation: "round-robin"
+		crypto:         "ecdsa"
+		communication:  "clique"
+		byzantineStrategy: {
+			fork: [2]
+		}
+		replicaHosts: ["localhost"]
+		clientHosts: ["localhost"]
+		replicas: 4
+		clients:  1
+		locations: ["Rome", "Oslo", "London", "Munich"]
+		treePositions: [3, 2, 1, 4]
+		branchFactor: 2
+	}
+}, {
+	config: {
+		consensus:      "fasthotstuff"
+		leaderRotation: "round-robin"
+		crypto:         "ecdsa"
+		communication:  "kauri"
+		byzantineStrategy: {
+			silence: [2]
+		}
+		replicaHosts: ["localhost"]
+		clientHosts: ["localhost"]
+		replicas: 4
+		clients:  1
+		locations: ["Rome", "Oslo", "London", "Munich"]
+		treePositions: [3, 2, 1, 4]
+		branchFactor: 2
+	}
+}, {
+	config: {
+		consensus:      "chainedhotstuff"
+		leaderRotation: "round-robin"
+		crypto:         "ecdsa"
+		communication:  "kauri"
+		byzantineStrategy: {
+			"": []
+		}
+		replicaHosts: ["localhost"]
+		clientHosts: ["localhost"]
+		replicas: 4
+		clients:  1
+		locations: ["Rome", "Oslo", "London", "Munich"]
+		treePositions: [3, 2, 1, 4]
+		branchFactor: 2
+	}
+}]

--- a/internal/config/testdata/sweep-experiments.cue
+++ b/internal/config/testdata/sweep-experiments.cue
@@ -1,0 +1,47 @@
+package config
+
+// This file defines a configuration for running experiments with different parameters.
+// Use the following command to generate the `experiments.cue` file:
+//   cue eval --out cue -e config.experiments exp-config.cue > experiments.cue
+config: {
+	// Shared static settings
+	shared: {
+		replicaHosts: ["localhost"]
+		clientHosts: ["localhost"]
+		replicas: 4
+		clients:  1
+		locations: ["Rome", "Oslo", "London", "Munich"]
+		treePositions: [3, 2, 1, 4]
+		branchFactor: 2
+	}
+
+	// Parameter sweeps
+	params: {
+		consensus: ["chainedhotstuff", "simplehotstuff"]
+		leaderRotation: ["round-robin", "fixed"]
+		crypto: ["ecdsa"]
+		communication: ["clique", "kauri"]
+		byz: [
+			{strategy: "", targets: []},
+			{strategy: "silence", targets: [2]},
+		]
+	}
+
+	// Cross-product into experiments
+	experiments: [
+		for cs in params.consensus
+		for ld in params.leaderRotation
+		for cr in params.crypto
+		for cm in params.communication
+		for bc in params.byz {
+			config: {
+				shared
+				consensus:      cs
+				leaderRotation: ld
+				crypto:         cr
+				communication:  cm
+				byzantineStrategy: {(bc.strategy): bc.targets}
+			}
+		},
+	]
+}


### PR DESCRIPTION
This adds support for creating parameter sweeps in cue that directly translates into runnable ExperimentConfig structs.

- **chore: tweak make test log output**
- **chore: remove unused imports from plot/main.go**
- **feat: add support for processing experiment configurations**
- **feat: add support for processing cue-based param sweeps directly**
