### PR TITLE
Experiment support for parameter sweeps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ __debug_bin
 # binaries
 /hotstuff
 /plot
+/hscov
 
 # other
 *.in

--- a/.vscode/dict.txt
+++ b/.vscode/dict.txt
@@ -16,6 +16,7 @@ cmdqueue
 Cmds
 cmpopts
 CODECOV
+covdata
 covermode
 coverpkg
 coverprofile
@@ -40,6 +41,7 @@ fgprofprofile
 fixedleader
 gcflags
 gcov
+GOCOVERDIR
 gocyclo
 golangci
 golint
@@ -53,6 +55,7 @@ hostnames
 HOTSTUFF
 hotstuffgorums
 hotstuffpb
+hscov
 iagotest
 ICDCS
 iface
@@ -105,6 +108,7 @@ SSWU
 structs
 subconfiguration
 testutil
+textfmt
 throughputvslatency
 timestamppb
 TMPDIR

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -29,8 +29,10 @@ func runController() {
 
 	cuePath := viper.GetString("cue")
 	if cuePath != "" {
-		cfg, err = config.NewCue(cuePath, cfg)
+		// cfg, err = config.NewCue(cuePath, cfg)
+		expConfig, err := config.NewCueExperiments(cuePath, cfg)
 		checkf("config error when loading %s: %v", cuePath, err)
+		cfg = expConfig[0] // Use the first experiment config for now
 	}
 
 	if cfg.RandomTree {

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -32,7 +32,6 @@ func runController() {
 	if cuePath != "" {
 		for expConfig, err := range config.Experiments(cuePath, cfg) {
 			checkf("config error when loading %s: %v", cuePath, err)
-			fmt.Println(expConfig.PrettyPrint(120))
 			runSingleExperiment(expConfig)
 		}
 	} else {
@@ -41,6 +40,7 @@ func runController() {
 }
 
 func runSingleExperiment(cfg *config.ExperimentConfig) {
+	fmt.Println(cfg.PrettyPrint(120))
 	if cfg.RandomTree {
 		tree.Shuffle(cfg.TreePositions)
 	}

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -32,7 +32,7 @@ func runController() {
 	if cuePath != "" {
 		for expConfig, err := range config.Experiments(cuePath, cfg) {
 			checkf("config error when loading %s: %v", cuePath, err)
-			fmt.Printf("%s\n", expConfig.PrettyPrint(120))
+			fmt.Println(expConfig.PrettyPrint(120))
 			runSingleExperiment(expConfig)
 		}
 	} else {

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"bufio"
+	"fmt"
 	"io"
 	"log"
 	"net"
@@ -29,12 +30,17 @@ func runController() {
 
 	cuePath := viper.GetString("cue")
 	if cuePath != "" {
-		// cfg, err = config.NewCue(cuePath, cfg)
-		expConfig, err := config.NewCueExperiments(cuePath, cfg)
-		checkf("config error when loading %s: %v", cuePath, err)
-		cfg = expConfig[0] // Use the first experiment config for now
+		for expConfig, err := range config.Experiments(cuePath, cfg) {
+			checkf("config error when loading %s: %v", cuePath, err)
+			fmt.Printf("%s\n", expConfig.PrettyPrint(120))
+			runSingleExperiment(expConfig)
+		}
+	} else {
+		runSingleExperiment(cfg)
 	}
+}
 
+func runSingleExperiment(cfg *config.ExperimentConfig) {
 	if cfg.RandomTree {
 		tree.Shuffle(cfg.TreePositions)
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -251,7 +251,7 @@ func (c *ExperimentConfig) AssignClients() ClientMap {
 }
 
 // IsLocal returns true if both the replica and client hosts slices
-// contain one instance of "localhost". See NewLocal.
+// contain one instance of "localhost".
 func (c *ExperimentConfig) IsLocal() bool {
 	if len(c.ClientHosts) > 1 || len(c.ReplicaHosts) > 1 {
 		return false

--- a/internal/config/config_string.go
+++ b/internal/config/config_string.go
@@ -2,6 +2,8 @@ package config
 
 import (
 	"fmt"
+	"reflect"
+	"slices"
 	"strconv"
 	"strings"
 )
@@ -52,4 +54,202 @@ func (c *ExperimentConfig) String() string {
 	}
 	s.WriteString("}")
 	return s.String()
+}
+
+// configurationTemplate holds separate slices for slice-fields and scalar-fields, plus key-column width.
+type configurationTemplate struct {
+	SliceKeys  []string
+	SliceVals  []string
+	ScalarKeys []string
+	ScalarVals []string
+	KeyWidths  [3]int
+	ValWidths  [3]int
+}
+
+// addSliceField adds a slice/map field to the template data
+func (td *configurationTemplate) addSliceField(name, value string) {
+	td.SliceKeys = append(td.SliceKeys, name)
+	td.SliceVals = append(td.SliceVals, value)
+}
+
+// addScalarField adds a scalar field to the template data
+func (td *configurationTemplate) addScalarField(name, value string) {
+	td.ScalarKeys = append(td.ScalarKeys, name)
+	td.ScalarVals = append(td.ScalarVals, value)
+}
+
+// computeColumnWidths based on the longest key for the key column and
+// longest value for the value column.
+func (td *configurationTemplate) computeColumnWidths() {
+	numRows := (len(td.ScalarKeys) + 2) / 3
+
+	for i, key := range td.ScalarKeys {
+		col := i / numRows // the column this index belongs to
+		td.KeyWidths[col] = max(td.KeyWidths[col], len(key))
+	}
+	for i, val := range td.ScalarVals {
+		col := i / numRows // the column this index belongs to
+		td.ValWidths[col] = max(td.ValWidths[col], len(val))
+	}
+}
+
+// formatSliceLines renders slice fields manually.
+func (td *configurationTemplate) formatSliceLines() []string {
+	var sliceLines []string
+	// determine the width of the slice key column based on the longest key
+	var sliceKeyWidth int
+	for _, key := range td.SliceKeys {
+		if len(key) > sliceKeyWidth {
+			sliceKeyWidth = len(key)
+		}
+	}
+	for i, key := range td.SliceKeys {
+		line := fmt.Sprintf("%-*s: %s", sliceKeyWidth, key, td.SliceVals[i])
+		sliceLines = append(sliceLines, line)
+	}
+	return sliceLines
+}
+
+const columnSeparatorWidth = 4
+
+// formatScalarLines builds scalar fields in column-first order
+func (td *configurationTemplate) formatScalarLines() []string {
+	var lines []string
+	numRows := (len(td.ScalarKeys) + 2) / 3
+
+	for row := range numRows {
+		var b strings.Builder
+		for col := range 3 {
+			i := row + col*numRows
+			if i < len(td.ScalarKeys) {
+				key, val := td.ScalarKeys[i], td.ScalarVals[i]
+				// format: key (left-aligned) + ": " + value (left-aligned)
+				b.WriteString(fmt.Sprintf("%-*s: %-*s", td.KeyWidths[col], key, td.ValWidths[col], val))
+				// add separator if not the last column
+				if col < 2 {
+					b.WriteString(strings.Repeat(" ", columnSeparatorWidth))
+				}
+			}
+		}
+		lines = append(lines, b.String())
+	}
+	return lines
+}
+
+// PrettyPrint formats ExperimentConfig into a star-bordered box:
+// - slice fields and map fields: one column, printed first
+// - scalar fields: three columns, ordered top-to-bottom, printed after separator
+// - maxWidth: cap with ellipsis
+func (c ExperimentConfig) PrettyPrint(maxWidth int) string {
+	v := reflect.ValueOf(c)
+	t := v.Type()
+	var sd configurationTemplate
+	for i := range v.NumField() {
+		name := t.Field(i).Name
+		fv := v.Field(i).Interface()
+		switch x := fv.(type) {
+		case []string:
+			val := formatSliceString(x, maxWidth-len(name)-2)
+			sd.addSliceField(name, val)
+		case []uint32:
+			val := formatSliceUint32(x, maxWidth-len(name)-2)
+			sd.addSliceField(name, val)
+		case map[string][]uint32:
+			val := formatMapStringSliceUint32(x, maxWidth-len(name)-2)
+			sd.addSliceField(name, val)
+		default:
+			val := fmt.Sprint(fv)
+			sd.addScalarField(name, val)
+		}
+	}
+
+	sd.computeColumnWidths()
+	sliceLines := sd.formatSliceLines()
+	scalarLines := sd.formatScalarLines()
+
+	width := max(longestLine(sliceLines), longestLine(scalarLines))
+
+	allLines := make([]string, 0, len(sliceLines)+len(scalarLines)+1)
+	allLines = append(allLines, sliceLines...)
+	allLines = append(allLines, strings.Repeat("-", width))
+	allLines = append(allLines, scalarLines...)
+
+	// print border and experiment configuration lines
+	border := strings.Repeat("*", width)
+	var out strings.Builder
+	out.WriteString(border + "\n")
+	for _, line := range allLines {
+		out.WriteString(line + "\n")
+	}
+	out.WriteString(border + "\n")
+	return out.String()
+}
+
+// longestLine returns the length of the longest line in s.
+func longestLine(s []string) int {
+	longest := slices.MaxFunc(s, func(a, b string) int {
+		return len(a) - len(b)
+	})
+	return len(longest)
+}
+
+// formatSliceString formats a []string into "[a b c … z]" with ellipsis if too long.
+func formatSliceString(s []string, maxLen int) string {
+	// check if full string fits within maxLen
+	if f := fmt.Sprintf("%s", s); len(f) <= maxLen {
+		return f
+	}
+	// since we're past the first check, we know we need ellipsis.
+
+	// Find the maximum number of elements that can fit in the string,
+	// including the first element, ellipsis, and the last element.
+	var parts []string
+	lastElem := len(s) - 1
+	for i := range lastElem { // iterate over all but the last element
+		// try adding the current element with ellipsis and last element
+		testParts := append(parts, s[i], "…", s[lastElem])
+		// if adding this element makes it too long, stop here
+		if f := fmt.Sprintf("%s", testParts); len(f) > maxLen {
+			break
+		}
+		// otherwise, add this element to our parts
+		parts = append(parts, s[i])
+	}
+	// couldn't fit any elements, use the minimal representation: [first … last]
+	if len(parts) == 0 {
+		parts = append(parts, s[0])
+	}
+	// add ellipsis and last element
+	parts = append(parts, "…", s[lastElem])
+	return fmt.Sprintf("%s", parts)
+}
+
+// formatSliceUint32 formats a []uint32 into “[1 2 3 … 9]” with ellipsis if too long.
+func formatSliceUint32(s []uint32, maxLen int) string {
+	str := make([]string, len(s))
+	for i, v := range s {
+		str[i] = fmt.Sprint(v)
+	}
+	return formatSliceString(str, maxLen)
+}
+
+// formatMapStringSliceUint32 formats a map[string][]uint32 into a string representation.
+func formatMapStringSliceUint32(m map[string][]uint32, maxLen int) string {
+	if len(m) == 0 {
+		return "{}"
+	}
+	var parts []string
+	for key, vals := range m {
+		valStr := formatSliceUint32(vals, maxLen/2) // Use half maxLen for each value
+		parts = append(parts, fmt.Sprintf("%s: %s", key, valStr))
+	}
+	out := "{" + strings.Join(parts, ", ") + "}"
+	if len(out) <= maxLen {
+		return out
+	}
+	// If too long, just show the first key-value pair
+	if len(parts) > 0 {
+		return "{" + parts[0] + ", …}"
+	}
+	return "{…}"
 }

--- a/internal/config/cue.go
+++ b/internal/config/cue.go
@@ -4,6 +4,7 @@ import (
 	_ "embed"
 	"errors"
 	"fmt"
+	"iter"
 	"os"
 
 	"cuelang.org/go/cue"
@@ -13,87 +14,92 @@ import (
 //go:embed schema.cue
 var schemaFile string
 
-// NewCue loads a cue configuration from filename and returns a ExperimentConfig struct.
-// The configuration is validated against the schema embedded in the binary.
+// NewCueExperiments loads a cue configuration from filename and returns a list
+// of ExperimentConfig structs.
+// The configuration is validated against the embedded schema.
 // One can specify the `base` config to overwrite its values from the Cue config.
 // Leave `base` nil to construct a Cue config from scratch.
-func NewCue(filename string, base *ExperimentConfig) (*ExperimentConfig, error) {
-	ctx := cuecontext.New()
-	schema := ctx.CompileString(schemaFile).LookupPath(cue.ParsePath("config"))
-	if schema.Err() != nil {
-		return nil, schema.Err()
+func NewCueExperiments(filename string, base *ExperimentConfig) ([]*ExperimentConfig, error) {
+	var out []*ExperimentConfig
+	for ec, err := range Experiments(filename, base) {
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, ec)
 	}
-	b, err := os.ReadFile(filename)
-	if err != nil {
-		return nil, err
-	}
-	cfg := ctx.CompileString(string(b)).LookupPath(cue.ParsePath("config"))
-	if cfg.Err() != nil {
-		return nil, cfg.Err()
-	}
-	unified := schema.Unify(cfg)
-	if err := unified.Validate(cue.Concrete(true)); err != nil {
-		return nil, err
-	}
+	return out, nil
+}
 
+// Experiments returns an iterator over experiment configurations that yields
+// an ExperimentConfig and error for each experiment. It processes the cue file and
+// validates each configuration against the schema. If [base] is non-nil, it is used
+// to overwrite values in the Cue config, e.g., specified on the command line.
+func Experiments(filename string, base *ExperimentConfig) iter.Seq2[*ExperimentConfig, error] {
 	if base == nil {
 		base = &ExperimentConfig{}
 	}
+	return func(yield func(*ExperimentConfig, error) bool) {
+		ctx := cuecontext.New()
+		configSchema := ctx.CompileString(schemaFile).LookupPath(cue.ParsePath("config"))
+		if configSchema.Err() != nil {
+			yield(nil, configSchema.Err())
+			return
+		}
 
-	if err := cfg.Decode(base); err != nil {
-		return nil, err
+		b, err := os.ReadFile(filename)
+		if err != nil {
+			yield(nil, err)
+			return
+		}
+		elem := ctx.CompileString(string(b), cue.Filename(filename))
+		if elem.Err() != nil {
+			yield(nil, elem.Err())
+			return
+		}
+
+		// check if elem contains an iterator that can yield a list of experiments
+		it, err := cueIterator(elem)
+		if err != nil {
+			// if not an iterator, check if elem is a single config
+			yield(decodeConfig(elem, configSchema, base))
+			return
+		}
+		for it.Next() {
+			config := it.Value()
+			if !yield(decodeConfig(config, configSchema, base)) {
+				return
+			}
+		}
 	}
-	return base, nil
 }
 
-func NewCueExperiments(filename string) ([]*ExperimentConfig, error) {
-	ctx := cuecontext.New()
-	schema := ctx.CompileString(schemaFile).LookupPath(cue.ParsePath("config"))
-	if schema.Err() != nil {
-		return nil, schema.Err()
+// cueIterator returns an iterator over a list of experiments, or
+// one that expands into a list of experiments.
+func cueIterator(elem cue.Value) (cue.Iterator, error) {
+	it, e1 := elem.List()
+	if e1 == nil {
+		return it, nil
 	}
-	// read and compile the experiments file (top-level array)
-	b, err := os.ReadFile(filename)
-	if err != nil {
+	listVal := elem.LookupPath(cue.ParsePath("config.experiments"))
+	if e2 := listVal.Err(); e2 != nil {
+		return cue.Iterator{}, errors.Join(e1, e2)
+	}
+	return listVal.List()
+}
+
+// decodeConfig decodes a cue.Value into an ExperimentConfig, validating it against the schema.
+func decodeConfig(elem, schema cue.Value, base *ExperimentConfig) (*ExperimentConfig, error) {
+	config := elem.LookupPath(cue.ParsePath("config")) // config is a { config: { … } }
+	if config.Err() != nil {
+		return nil, fmt.Errorf("failed to get config from cue file: %w", config.Err())
+	}
+	unified := schema.Unify(config)
+	if err := unified.Validate(cue.Concrete(true)); err != nil {
 		return nil, err
 	}
-	experimentList := ctx.CompileString(string(b), cue.Filename(filename))
-	if experimentList.Err() != nil {
-		return nil, experimentList.Err()
+	ec := base.Clone()
+	if err := unified.Decode(ec); err != nil {
+		return nil, err
 	}
-	var head cue.Value
-	var errMissing error
-	// lookup the experiments in the compiled file
-	expandList := experimentList.LookupPath(cue.ParsePath("config.experiments"))
-	if expandList.Err() != nil {
-		errMissing = expandList.Err() // missing config.experiments
-		head = experimentList.Value() // file may contain a list of experiments
-	} else {
-		head = expandList.Value() // file may expanded into a list of experiments
-	}
-
-	// walk the list
-	iter, err := head.List()
-	if err != nil {
-		return nil, fmt.Errorf("experiments file must be or expand into an array: %w", errors.Join(errMissing, err))
-	}
-	var out []*ExperimentConfig
-	for iter.Next() {
-		elem := iter.Value() // { config: { … } }
-		cfg := elem.LookupPath(cue.ParsePath("config"))
-		if cfg.Err() != nil {
-			return nil, cfg.Err()
-		}
-		unified := schema.Unify(cfg)
-		if err := unified.Validate(cue.Concrete(true)); err != nil {
-			return nil, err
-		}
-		var ec ExperimentConfig
-		if err := unified.Decode(&ec); err != nil {
-			return nil, err
-		}
-		out = append(out, &ec)
-	}
-
-	return out, nil
+	return ec, nil
 }

--- a/internal/config/cue.go
+++ b/internal/config/cue.go
@@ -14,26 +14,10 @@ import (
 //go:embed schema.cue
 var schemaFile string
 
-// NewCueExperiments loads a cue configuration from filename and returns a list
-// of ExperimentConfig structs.
-// The configuration is validated against the embedded schema.
-// One can specify the `base` config to overwrite its values from the Cue config.
-// Leave `base` nil to construct a Cue config from scratch.
-func NewCueExperiments(filename string, base *ExperimentConfig) ([]*ExperimentConfig, error) {
-	var out []*ExperimentConfig
-	for ec, err := range Experiments(filename, base) {
-		if err != nil {
-			return nil, err
-		}
-		out = append(out, ec)
-	}
-	return out, nil
-}
-
 // Experiments returns an iterator over experiment configurations that yields
-// an ExperimentConfig and error for each experiment. It processes the cue file and
-// validates each configuration against the schema. If [base] is non-nil, it is used
-// to overwrite values in the Cue config, e.g., specified on the command line.
+// an ExperimentConfig for each experiment, unless there was an error. It processes the
+// cue file and validates each configuration against the schema. If [base] is non-nil,
+// it is used to overwrite values in the Cue config, e.g., specified on the command line.
 func Experiments(filename string, base *ExperimentConfig) iter.Seq2[*ExperimentConfig, error] {
 	if base == nil {
 		base = &ExperimentConfig{}

--- a/internal/config/cue.go
+++ b/internal/config/cue.go
@@ -2,6 +2,8 @@ package config
 
 import (
 	_ "embed"
+	"errors"
+	"fmt"
 	"os"
 
 	"cuelang.org/go/cue"
@@ -42,4 +44,56 @@ func NewCue(filename string, base *ExperimentConfig) (*ExperimentConfig, error) 
 		return nil, err
 	}
 	return base, nil
+}
+
+func NewCueExperiments(filename string) ([]*ExperimentConfig, error) {
+	ctx := cuecontext.New()
+	schema := ctx.CompileString(schemaFile).LookupPath(cue.ParsePath("config"))
+	if schema.Err() != nil {
+		return nil, schema.Err()
+	}
+	// read and compile the experiments file (top-level array)
+	b, err := os.ReadFile(filename)
+	if err != nil {
+		return nil, err
+	}
+	experimentList := ctx.CompileString(string(b), cue.Filename(filename))
+	if experimentList.Err() != nil {
+		return nil, experimentList.Err()
+	}
+	var head cue.Value
+	var errMissing error
+	// lookup the experiments in the compiled file
+	expandList := experimentList.LookupPath(cue.ParsePath("config.experiments"))
+	if expandList.Err() != nil {
+		errMissing = expandList.Err() // missing config.experiments
+		head = experimentList.Value() // file may contain a list of experiments
+	} else {
+		head = expandList.Value() // file may expanded into a list of experiments
+	}
+
+	// walk the list
+	iter, err := head.List()
+	if err != nil {
+		return nil, fmt.Errorf("experiments file must be or expand into an array: %w", errors.Join(errMissing, err))
+	}
+	var out []*ExperimentConfig
+	for iter.Next() {
+		elem := iter.Value() // { config: { … } }
+		cfg := elem.LookupPath(cue.ParsePath("config"))
+		if cfg.Err() != nil {
+			return nil, cfg.Err()
+		}
+		unified := schema.Unify(cfg)
+		if err := unified.Validate(cue.Concrete(true)); err != nil {
+			return nil, err
+		}
+		var ec ExperimentConfig
+		if err := unified.Decode(&ec); err != nil {
+			return nil, err
+		}
+		out = append(out, &ec)
+	}
+
+	return out, nil
 }

--- a/internal/config/cue_test.go
+++ b/internal/config/cue_test.go
@@ -73,6 +73,20 @@ func TestNewCue(t *testing.T) {
 		Replicas:     3,
 		Clients:      2,
 	}
+	exp := &config.ExperimentConfig{
+		ReplicaHosts:      []string{"localhost"},
+		ClientHosts:       []string{"localhost"},
+		Replicas:          4,
+		Clients:           1,
+		Locations:         []string{"Rome", "Oslo", "London", "Munich"},
+		TreePositions:     []uint32{3, 2, 1, 4},
+		BranchFactor:      2,
+		Consensus:         "chainedhotstuff",
+		Communication:     "clique",
+		Crypto:            "ecdsa",
+		LeaderRotation:    "round-robin",
+		ByzantineStrategy: map[string][]uint32{"": {}},
+	}
 	tests := []struct {
 		name     string
 		filename string
@@ -89,6 +103,7 @@ func TestNewCue(t *testing.T) {
 		{name: "InvalidLocationsSize", filename: "invalid-loc-size.cue", wantCfg: nil, wantErr: true},
 		{name: "InvalidTree", filename: "invalid-tree.cue", wantCfg: nil, wantErr: true},
 		{name: "Invalid2TreeOnly", filename: "invalid-tree-only.cue", wantCfg: nil, wantErr: true},
+		{name: "Experiments", filename: "exp.cue", wantCfg: exp, wantErr: false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/config/cue_test.go
+++ b/internal/config/cue_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/relab/hotstuff/internal/config"
 )
 
-func TestNewCue(t *testing.T) {
+func TestExperimentsIteratorSingle(t *testing.T) {
 	replicaHosts := []string{"bbchain1", "bbchain2", "bbchain3", "bbchain4", "bbchain5", "bbchain6"}
 	clientHosts := []string{"bbchain7", "bbchain8"}
 	locations := []string{"Melbourne", "Toronto", "Prague", "Paris", "Tokyo", "Amsterdam", "Auckland", "Moscow", "Stockholm", "London"}
@@ -17,6 +17,12 @@ func TestNewCue(t *testing.T) {
 	byzantineStrategy := map[string][]uint32{
 		"silent": {2, 5},
 		"slow":   {4},
+	}
+	defaultModules := &config.ExperimentConfig{
+		Consensus:      "chainedhotstuff",
+		Communication:  "clique",
+		Crypto:         "ecdsa",
+		LeaderRotation: "round-robin",
 	}
 	validLocOnlyCfg := &config.ExperimentConfig{
 		ReplicaHosts: replicaHosts,
@@ -81,10 +87,6 @@ func TestNewCue(t *testing.T) {
 		Locations:         []string{"Rome", "Oslo", "London", "Munich"},
 		TreePositions:     []uint32{3, 2, 1, 4},
 		BranchFactor:      2,
-		Consensus:         "chainedhotstuff",
-		Communication:     "clique",
-		Crypto:            "ecdsa",
-		LeaderRotation:    "round-robin",
 		ByzantineStrategy: map[string][]uint32{"": {}},
 	}
 	tests := []struct {
@@ -107,19 +109,29 @@ func TestNewCue(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotCfg, err := config.NewCue(filepath.Join("testdata", tt.filename), nil)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("NewCue(%s) error = %v, wantErr %v", tt.filename, err, tt.wantErr)
-				return
-			}
-			if diff := cmp.Diff(tt.wantCfg, gotCfg); diff != "" {
-				t.Errorf("NewCue(%s) mismatch (-want +got):\n%s", tt.filename, diff)
+			for expConfig, err := range config.Experiments(filepath.Join("testdata", tt.filename), nil) {
+				if (err != nil) != tt.wantErr {
+					t.Errorf("Experiments(%s) error = %v, wantErr %v", tt.filename, err, tt.wantErr)
+				}
+				if (tt.wantCfg == nil && expConfig != nil) || (tt.wantCfg != nil && expConfig == nil) {
+					t.Errorf("Experiments(%s) mismatch: got %v, want %v", tt.filename, expConfig, tt.wantCfg)
+				}
+				if expConfig == nil && tt.wantCfg == nil {
+					return // both nil, no diff to check
+				}
+				if tt.wantCfg != nil {
+					// merge default modules into the wanted config
+					tt.wantCfg.Merge(defaultModules)
+				}
+				if diff := cmp.Diff(tt.wantCfg, expConfig); diff != "" {
+					t.Errorf("Experiments(%s) mismatch (-want +got):\n%s", tt.filename, diff)
+				}
 			}
 		})
 	}
 }
 
-func TestNewCueExperiment(t *testing.T) {
+func TestExperimentsIteratorMultiple(t *testing.T) {
 	fourExp := []*config.ExperimentConfig{
 		{
 			ReplicaHosts:      []string{"localhost"},
@@ -187,22 +199,28 @@ func TestNewCueExperiment(t *testing.T) {
 	}{
 		{name: "FourExperiments", filename: "four-experiments.cue", wantCfg: fourExp, wantLen: 4, wantErr: false},
 		{name: "SweepExperiments", filename: "sweep-experiments.cue", wantLen: 16, wantErr: false},
+		{name: "NoSuchExperiment", filename: "no-such-experiment.cue", wantLen: 0, wantErr: true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotCfg, err := config.NewCueExperiments(filepath.Join("testdata", tt.filename))
-			if (err != nil) != tt.wantErr {
-				t.Errorf("NewCueExperiments(%s) error = %v, want %v", tt.filename, err, tt.wantErr)
-				return
+			expCnt := 0
+			for gotCfg, err := range config.Experiments(filepath.Join("testdata", tt.filename), nil) {
+				if (err != nil) != tt.wantErr {
+					t.Errorf("Experiments(%s) error = %v, wantErr %v", tt.filename, err, tt.wantErr)
+				}
+				if gotCfg != nil {
+					expCnt++ // only count non-nil configs towards the wanted length
+				}
+				if tt.wantCfg == nil {
+					continue // skip diff check for large parameter sweeps
+				}
+				wantCfg := tt.wantCfg[expCnt-1]
+				if diff := cmp.Diff(wantCfg, gotCfg); diff != "" {
+					t.Errorf("Experiments(%s) mismatch (-want +got):\n%s", tt.filename, diff)
+				}
 			}
-			if len(gotCfg) != tt.wantLen {
-				t.Errorf("NewCueExperiments(%s) length = %d, want %d", tt.filename, len(gotCfg), tt.wantLen)
-			}
-			if tt.wantCfg == nil {
-				return // skip diff check for large parameter sweeps
-			}
-			if diff := cmp.Diff(tt.wantCfg, gotCfg); diff != "" {
-				t.Errorf("NewCueExperiments(%s) mismatch (-want +got):\n%s", tt.filename, diff)
+			if expCnt != tt.wantLen {
+				t.Errorf("Experiments(%s) length = %d, want %d", tt.filename, expCnt, tt.wantLen)
 			}
 		})
 	}

--- a/internal/config/cue_test.go
+++ b/internal/config/cue_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/relab/hotstuff/internal/config"
 )
 
-func TestLoad(t *testing.T) {
+func TestNewCue(t *testing.T) {
 	replicaHosts := []string{"bbchain1", "bbchain2", "bbchain3", "bbchain4", "bbchain5", "bbchain6"}
 	clientHosts := []string{"bbchain7", "bbchain8"}
 	locations := []string{"Melbourne", "Toronto", "Prague", "Paris", "Tokyo", "Amsterdam", "Auckland", "Moscow", "Stockholm", "London"}
@@ -94,11 +94,100 @@ func TestLoad(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			gotCfg, err := config.NewCue(filepath.Join("testdata", tt.filename), nil)
 			if (err != nil) != tt.wantErr {
-				t.Errorf("Load(%s) error = %v, wantErr %v", tt.filename, err, tt.wantErr)
+				t.Errorf("NewCue(%s) error = %v, wantErr %v", tt.filename, err, tt.wantErr)
 				return
 			}
-			if diff := cmp.Diff(gotCfg, tt.wantCfg); diff != "" {
-				t.Errorf("Load(%s) mismatch (-want +got):\n%s", tt.filename, diff)
+			if diff := cmp.Diff(tt.wantCfg, gotCfg); diff != "" {
+				t.Errorf("NewCue(%s) mismatch (-want +got):\n%s", tt.filename, diff)
+			}
+		})
+	}
+}
+
+func TestNewCueExperiment(t *testing.T) {
+	fourExp := []*config.ExperimentConfig{
+		{
+			ReplicaHosts:      []string{"localhost"},
+			ClientHosts:       []string{"localhost"},
+			Replicas:          4,
+			Clients:           1,
+			Locations:         []string{"Rome", "Oslo", "London", "Munich"},
+			TreePositions:     []uint32{3, 2, 1, 4},
+			BranchFactor:      2,
+			Consensus:         "chainedhotstuff",
+			Communication:     "clique",
+			Crypto:            "ecdsa",
+			LeaderRotation:    "round-robin",
+			ByzantineStrategy: map[string][]uint32{"": {}},
+		},
+		{
+			ReplicaHosts:      []string{"localhost"},
+			ClientHosts:       []string{"localhost"},
+			Replicas:          4,
+			Clients:           1,
+			Locations:         []string{"Rome", "Oslo", "London", "Munich"},
+			TreePositions:     []uint32{3, 2, 1, 4},
+			BranchFactor:      2,
+			Consensus:         "simplehotstuff",
+			Communication:     "clique",
+			Crypto:            "ecdsa",
+			LeaderRotation:    "round-robin",
+			ByzantineStrategy: map[string][]uint32{"fork": {2}},
+		},
+		{
+			ReplicaHosts:      []string{"localhost"},
+			ClientHosts:       []string{"localhost"},
+			Replicas:          4,
+			Clients:           1,
+			Locations:         []string{"Rome", "Oslo", "London", "Munich"},
+			TreePositions:     []uint32{3, 2, 1, 4},
+			BranchFactor:      2,
+			Consensus:         "fasthotstuff",
+			Communication:     "kauri",
+			Crypto:            "ecdsa",
+			LeaderRotation:    "round-robin",
+			ByzantineStrategy: map[string][]uint32{"silence": {2}},
+		},
+		{
+			ReplicaHosts:      []string{"localhost"},
+			ClientHosts:       []string{"localhost"},
+			Replicas:          4,
+			Clients:           1,
+			Locations:         []string{"Rome", "Oslo", "London", "Munich"},
+			TreePositions:     []uint32{3, 2, 1, 4},
+			BranchFactor:      2,
+			Consensus:         "chainedhotstuff",
+			Communication:     "kauri",
+			Crypto:            "ecdsa",
+			LeaderRotation:    "round-robin",
+			ByzantineStrategy: map[string][]uint32{"": {}},
+		},
+	}
+	tests := []struct {
+		name     string
+		filename string
+		wantCfg  []*config.ExperimentConfig
+		wantLen  int
+		wantErr  bool
+	}{
+		{name: "FourExperiments", filename: "four-experiments.cue", wantCfg: fourExp, wantLen: 4, wantErr: false},
+		{name: "SweepExperiments", filename: "sweep-experiments.cue", wantLen: 16, wantErr: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotCfg, err := config.NewCueExperiments(filepath.Join("testdata", tt.filename))
+			if (err != nil) != tt.wantErr {
+				t.Errorf("NewCueExperiments(%s) error = %v, want %v", tt.filename, err, tt.wantErr)
+				return
+			}
+			if len(gotCfg) != tt.wantLen {
+				t.Errorf("NewCueExperiments(%s) length = %d, want %d", tt.filename, len(gotCfg), tt.wantLen)
+			}
+			if tt.wantCfg == nil {
+				return // skip diff check for large parameter sweeps
+			}
+			if diff := cmp.Diff(tt.wantCfg, gotCfg); diff != "" {
+				t.Errorf("NewCueExperiments(%s) mismatch (-want +got):\n%s", tt.filename, diff)
 			}
 		})
 	}

--- a/internal/config/exp-config.cue
+++ b/internal/config/exp-config.cue
@@ -1,0 +1,48 @@
+package config
+
+// This file defines a configuration for running experiments with different parameters.
+// Use the following command to generate the `experiments.cue` file:
+//   cue eval --out cue -e config.experiments exp-config.cue > experiments.cue
+config: {
+	// Shared static settings
+	shared: {
+		replicaHosts: ["localhost"]
+		clientHosts: ["localhost"]
+		replicas: 4
+		clients:  1
+		locations: ["Rome", "Oslo", "London", "Munich"]
+		treePositions: [3, 2, 1, 4]
+		branchFactor: 2
+	}
+
+	// Parameter sweeps
+	params: {
+		consensus: ["chainedhotstuff", "simplehotstuff", "fasthotstuff"]
+		leaderRotation: ["round-robin", "fixed", "carousel", "reputation"]
+		crypto: ["ecdsa", "eddsa", "bls12"]
+		communication: ["clique", "kauri"]
+		byz: [
+			{strategy: "", targets: []},
+			{strategy: "fork", targets: [2]},
+			{strategy: "silence", targets: [2]},
+		]
+	}
+
+	// Cross-product into experiments
+	experiments: [
+		for cs in params.consensus
+		for ld in params.leaderRotation
+		for cr in params.crypto
+		for cm in params.communication
+		for bc in params.byz {
+			config: {
+				shared
+				consensus:      cs
+				leaderRotation: ld
+				crypto:         cr
+				communication:  cm
+				byzantineStrategy: {(bc.strategy): bc.targets}
+			}
+		},
+	]
+}

--- a/internal/config/schema.cue
+++ b/internal/config/schema.cue
@@ -31,6 +31,15 @@ config: {
 		branchFactor!: int & >1 & <=div(replicas, 2)
 	}
 
+	// Consensus algorithm to use. (Default: "chainedhotstuff")
+	consensus: *"chainedhotstuff" | "simplehotstuff" | "fasthotstuff"
+	// Leader rotation strategy to use. (Default: "round-robin")
+	leaderRotation: *"round-robin" | "fixed" | "carousel" | "reputation"
+	// Cryptographic algorithm to use. (Default: "ecdsa")
+	crypto: *"ecdsa" | "eddsa" | "bls12"
+	// Communication protocol to use. (Default: "clique")
+	communication: *"clique" | "kauri"
+
 	// Byzantine strategy for different replicas (optional).
 	byzantineStrategy?: {
 		silent?: [...int & >=1 & <=replicas]

--- a/internal/config/testdata/exp.cue
+++ b/internal/config/testdata/exp.cue
@@ -1,0 +1,16 @@
+config: {
+	consensus:      "chainedhotstuff"
+	leaderRotation: "round-robin"
+	crypto:         "ecdsa"
+	communication:  "clique"
+	byzantineStrategy: {
+		"": []
+	}
+	replicaHosts: ["localhost"]
+	clientHosts: ["localhost"]
+	replicas: 4
+	clients:  1
+	locations: ["Rome", "Oslo", "London", "Munich"]
+	treePositions: [3, 2, 1, 4]
+	branchFactor: 2
+}

--- a/internal/config/testdata/four-experiments.cue
+++ b/internal/config/testdata/four-experiments.cue
@@ -1,0 +1,69 @@
+[{
+	config: {
+		consensus:      "chainedhotstuff"
+		leaderRotation: "round-robin"
+		crypto:         "ecdsa"
+		communication:  "clique"
+		byzantineStrategy: {
+			"": []
+		}
+		replicaHosts: ["localhost"]
+		clientHosts: ["localhost"]
+		replicas: 4
+		clients:  1
+		locations: ["Rome", "Oslo", "London", "Munich"]
+		treePositions: [3, 2, 1, 4]
+		branchFactor: 2
+	}
+}, {
+	config: {
+		consensus:      "simplehotstuff"
+		leaderRotation: "round-robin"
+		crypto:         "ecdsa"
+		communication:  "clique"
+		byzantineStrategy: {
+			fork: [2]
+		}
+		replicaHosts: ["localhost"]
+		clientHosts: ["localhost"]
+		replicas: 4
+		clients:  1
+		locations: ["Rome", "Oslo", "London", "Munich"]
+		treePositions: [3, 2, 1, 4]
+		branchFactor: 2
+	}
+}, {
+	config: {
+		consensus:      "fasthotstuff"
+		leaderRotation: "round-robin"
+		crypto:         "ecdsa"
+		communication:  "kauri"
+		byzantineStrategy: {
+			silence: [2]
+		}
+		replicaHosts: ["localhost"]
+		clientHosts: ["localhost"]
+		replicas: 4
+		clients:  1
+		locations: ["Rome", "Oslo", "London", "Munich"]
+		treePositions: [3, 2, 1, 4]
+		branchFactor: 2
+	}
+}, {
+	config: {
+		consensus:      "chainedhotstuff"
+		leaderRotation: "round-robin"
+		crypto:         "ecdsa"
+		communication:  "kauri"
+		byzantineStrategy: {
+			"": []
+		}
+		replicaHosts: ["localhost"]
+		clientHosts: ["localhost"]
+		replicas: 4
+		clients:  1
+		locations: ["Rome", "Oslo", "London", "Munich"]
+		treePositions: [3, 2, 1, 4]
+		branchFactor: 2
+	}
+}]

--- a/internal/config/testdata/sweep-experiments.cue
+++ b/internal/config/testdata/sweep-experiments.cue
@@ -1,0 +1,47 @@
+package config
+
+// This file defines a configuration for running experiments with different parameters.
+// Use the following command to generate the `experiments.cue` file:
+//   cue eval --out cue -e config.experiments exp-config.cue > experiments.cue
+config: {
+	// Shared static settings
+	shared: {
+		replicaHosts: ["localhost"]
+		clientHosts: ["localhost"]
+		replicas: 4
+		clients:  1
+		locations: ["Rome", "Oslo", "London", "Munich"]
+		treePositions: [3, 2, 1, 4]
+		branchFactor: 2
+	}
+
+	// Parameter sweeps
+	params: {
+		consensus: ["chainedhotstuff", "simplehotstuff"]
+		leaderRotation: ["round-robin", "fixed"]
+		crypto: ["ecdsa"]
+		communication: ["clique", "kauri"]
+		byz: [
+			{strategy: "", targets: []},
+			{strategy: "silence", targets: [2]},
+		]
+	}
+
+	// Cross-product into experiments
+	experiments: [
+		for cs in params.consensus
+		for ld in params.leaderRotation
+		for cr in params.crypto
+		for cm in params.communication
+		for bc in params.byz {
+			config: {
+				shared
+				consensus:      cs
+				leaderRotation: ld
+				crypto:         cr
+				communication:  cm
+				byzantineStrategy: {(bc.strategy): bc.targets}
+			}
+		},
+	]
+}

--- a/internal/orchestration/deploy.go
+++ b/internal/orchestration/deploy.go
@@ -8,10 +8,10 @@ package orchestration
 
 import (
 	"context"
+	"crypto/rand"
 	"errors"
 	"fmt"
 	"io"
-	"math/rand"
 	"path"
 	"path/filepath"
 	"strings"
@@ -58,7 +58,7 @@ func Deploy(g iago.Group, cfg DeployConfig) (workers map[string]WorkerSession, e
 
 	g.Run("Create temporary directory",
 		func(_ context.Context, host iago.Host) error {
-			tmpDir := "hotstuff." + randString(8)
+			tmpDir := "hotstuff." + rand.Text()[:8]
 			testDir := strings.TrimPrefix(tempDirPath(host, tmpDir), "/")
 			dataDir := testDir + "/data"
 			host.SetVar("test-dir", testDir)
@@ -259,15 +259,4 @@ func tempDirPath(host iago.Host, dirName string) string {
 		tmp = "/tmp"
 	}
 	return path.Join(tmp, dirName)
-}
-
-var rnd = rand.New(rand.NewSource(time.Now().UnixNano()))
-
-func randString(n int) string {
-	letters := []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789")
-	s := make([]rune, n)
-	for i := range s {
-		s[i] = letters[rnd.Intn(len(letters))]
-	}
-	return string(s)
 }

--- a/internal/orchestration/deploy.go
+++ b/internal/orchestration/deploy.go
@@ -197,6 +197,9 @@ func (w *workerSetup) Apply(_ context.Context, host iago.Host) (err error) {
 	dir := "/" + iago.GetStringVar(host, "data-dir")
 
 	var sb strings.Builder
+	sb.WriteString("GOCOVERDIR=")
+	sb.WriteString(dir)
+	sb.WriteString(" ")
 	sb.WriteString(iago.GetStringVar(host, "exe"))
 	sb.WriteString(" ")
 

--- a/scripts/local_config.cue
+++ b/scripts/local_config.cue
@@ -3,13 +3,6 @@ package config
 config: {
 	replicaHosts: ["localhost"]
 	clientHosts: ["localhost"]
-	replicas: 5
-	clients:  2
-
-	locations: ["Paris", "Rome", "Oslo", "London", "Munich"]
-	treePositions: [3, 2, 1, 4, 5]
-	branchFactor: 2
-	byzantineStrategy: {
-		silence: [1]
-	}
+	replicas: 4
+	clients:  1
 }

--- a/scripts/sweep.cue
+++ b/scripts/sweep.cue
@@ -1,0 +1,44 @@
+package config
+
+// This file defines a configuration for running experiments with different parameters.
+// Use the following command to generate the `experiments.cue` file:
+//   cue eval --out cue -e config.experiments exp-config.cue > experiments.cue
+config: {
+	// Shared static settings
+	shared: {
+		replicaHosts: ["localhost"]
+		clientHosts: ["localhost"]
+		replicas: 4
+		clients:  1
+	}
+
+	// Parameter sweeps
+	params: {
+		consensus: ["chainedhotstuff"]
+		leaderRotation: ["round-robin", "fixed"]
+		crypto: ["ecdsa", "eddsa"]
+		communication: ["clique"]
+		byz: [
+			{strategy: "", targets: []},
+			{strategy: "silence", targets: [2]},
+		]
+	}
+
+	// Cross-product into experiments
+	experiments: [
+		for cs in params.consensus
+		for ld in params.leaderRotation
+		for cr in params.crypto
+		for cm in params.communication
+		for bc in params.byz {
+			config: {
+				shared
+				consensus:      cs
+				leaderRotation: ld
+				crypto:         cr
+				communication:  cm
+				byzantineStrategy: {(bc.strategy): bc.targets}
+			}
+		},
+	]
+}


### PR DESCRIPTION
This adds support for creating parameter sweeps in cue that directly translates into runnable ExperimentConfig structs.

- **feat: add support for processing cue-based param sweeps directly**
- **feat: add support for processing experiment configurations**
