### PR TITLE
fix(worker): kauri tree is only added when kauri is enabled

### DIFF
--- a/internal/orchestration/worker.go
+++ b/internal/orchestration/worker.go
@@ -146,7 +146,7 @@ func (w *Worker) createReplica(opts *orchestrationpb.ReplicaOpts) (*replica.Repl
 	}
 	// setup core - used in replica and measurement framework
 	runtimeOpts := []core.RuntimeOption{}
-	if opts.TreeEnabled() && opts.GetCommunication() == comm.NameKauri {
+	if opts.KauriEnabled() {
 		runtimeOpts = append(runtimeOpts, core.WithKauriTree(newTree(opts)))
 	}
 	if opts.GetConsensus() == rules.NameFastHotStuff {

--- a/internal/proto/orchestrationpb/replica_opts.go
+++ b/internal/proto/orchestrationpb/replica_opts.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/relab/hotstuff"
+	"github.com/relab/hotstuff/protocol/comm"
 	"github.com/relab/hotstuff/security/crypto/keygen"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/durationpb"
@@ -53,11 +54,11 @@ func (x *ReplicaOpts) SetTreeOptions(branchFactor uint32, positions []uint32, tr
 	x.TreeDelta = durationpb.New(treeDelta)
 }
 
-// TreeEnabled returns true if there are tree positions defined,
+// KauriEnabled returns true if there are tree positions defined,
 // the branch factor is greater than 0, and the tree delta is valid (not zero).
 // This indicates that the replica is configured to use a tree structure for the Kauri protocol.
-func (x *ReplicaOpts) TreeEnabled() bool {
-	return len(x.TreePositions) > 0 && x.BranchFactor > 0 && x.TreeDelta.IsValid()
+func (x *ReplicaOpts) KauriEnabled() bool {
+	return len(x.TreePositions) > 0 && x.BranchFactor > 0 && x.TreeDelta.IsValid() && x.Communication == comm.NameKauri
 }
 
 func (x *ReplicaOpts) SetByzantineStrategy(strategy string) {


### PR DESCRIPTION
A fix could be potentially something like this. 
Such that kauriTree opts are only added when using kauri.