### PR TITLE
Simplify the Aggregate method signature

### DIFF
--- a/protocol/comm/clique.go
+++ b/protocol/comm/clique.go
@@ -43,7 +43,8 @@ func (hs *Clique) Disseminate(proposal *hotstuff.ProposeMsg, pc hotstuff.Partial
 }
 
 // Aggregate aggregates the vote or stores it if the replica is leader in the next view.
-func (hs *Clique) Aggregate(lastVote hotstuff.View, _ *hotstuff.ProposeMsg, pc hotstuff.PartialCert) error {
+func (hs *Clique) Aggregate(proposal *hotstuff.ProposeMsg, pc hotstuff.PartialCert) error {
+	lastVote := proposal.Block.View()
 	leaderID := hs.leaderRotation.GetLeader(lastVote + 1)
 	if leaderID == hs.config.ID() {
 		// if I am the leader in the next view, collect the vote for myself beforehand.

--- a/protocol/comm/comm.go
+++ b/protocol/comm/comm.go
@@ -12,7 +12,7 @@ type Disseminator interface {
 // Aggregator is an interface for handling incoming proposals and replying with a vote.
 type Aggregator interface {
 	// Aggregate handles incoming proposals and replies with a vote.
-	Aggregate(lastVote hotstuff.View, proposal *hotstuff.ProposeMsg, pc hotstuff.PartialCert) error
+	Aggregate(proposal *hotstuff.ProposeMsg, pc hotstuff.PartialCert) error
 }
 
 // Communication is an interface that combines Disseminator and Aggregator for convenience.

--- a/protocol/comm/comm_test.go
+++ b/protocol/comm/comm_test.go
@@ -68,7 +68,7 @@ func TestDisseminateAggregate(t *testing.T) {
 	// reusing the previous partial cert
 	// aggregating for view 2 to change the leader to 2 so clique will aggregate instead
 	// of storing the vote internally
-	err = clique.Aggregate(1, nil, pc)
+	err = clique.Aggregate(proposal, pc)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/protocol/comm/kauri.go
+++ b/protocol/comm/kauri.go
@@ -94,7 +94,7 @@ func (k *Kauri) reset() {
 	k.aggSent = false
 }
 
-func (k *Kauri) Aggregate(_ hotstuff.View, proposal *hotstuff.ProposeMsg, pc hotstuff.PartialCert) error {
+func (k *Kauri) Aggregate(proposal *hotstuff.ProposeMsg, pc hotstuff.PartialCert) error {
 	return k.Begin(proposal, pc)
 }
 

--- a/protocol/consensus/voter.go
+++ b/protocol/consensus/voter.go
@@ -61,7 +61,7 @@ func (v *Voter) OnValidPropose(proposal *hotstuff.ProposeMsg) (errs error) {
 		return errors.Join(errs, fmt.Errorf("vote failed: %w", err))
 	}
 	// send the vote if it was successful
-	if err := v.aggregator.Aggregate(v.LastVote(), proposal, pc); err != nil {
+	if err := v.aggregator.Aggregate(proposal, pc); err != nil {
 		return errors.Join(errs, fmt.Errorf("aggregate failed (view %d): %w", block.View(), err))
 	}
 	return errs


### PR DESCRIPTION
This avoids the lastVote in the Aggregate method since the proposal already holds this information via the proposal block's view.
