### PR TITLE
Guard against Byzantine leaders setting too high views

### DIFF
--- a/protocol/synchronizer/synchronizer.go
+++ b/protocol/synchronizer/synchronizer.go
@@ -105,6 +105,8 @@ func New(
 
 		proposalView := proposal.Block.View()
 		localView := s.state.View()
+
+		// alpha limits acceptable view drift, 10 is a temporary heuristic.
 		const alpha hotstuff.View = 10
 		if proposalView > localView+alpha {
 			s.logger.Warnf("Dropping proposal: proposal view too high (%v) >> replica's local view (%v)", proposalView, localView)


### PR DESCRIPTION
A suggestion on how a fix for a byzantine leader increasing the view number can look. For now it uses a constant alpha that other replicas can not be ahead of. If a proposal is ahead but not beyond the alpha it get delayed until the next view change.