### PR TITLE
Take RLock only once when creating new SyncInfo() in ViewStates

### DIFF
--- a/protocol/viewstates.go
+++ b/protocol/viewstates.go
@@ -67,6 +67,8 @@ func (s *ViewStates) UpdateHighQC(qc hotstuff.QuorumCert) (bool, error) {
 
 // UpdateHighTC updates HighTC if timeout certificate's view is higher than the current HighTC.
 func (s *ViewStates) UpdateHighTC(tc hotstuff.TimeoutCert) {
+	s.mut.Lock()
+	defer s.mut.Unlock()
 	if tc.View() > s.highTC.View() {
 		s.highTC = tc
 	}


### PR DESCRIPTION
Since SyncInfo() already takes the RLock, we can access the highQC and highTC fields directly when constructing a new SyncInfo object. There is no need to take the read lock 3 times in this case.

Fixes #207

