### PR TITLE
Fix missing underscore in imports to cmd/plot

### DIFF
--- a/cmd/plot/main.go
+++ b/cmd/plot/main.go
@@ -9,6 +9,10 @@ import (
 	"time"
 
 	"github.com/relab/hotstuff/metrics/plotting"
+
+	// ensure proto messages are registered so that they can be decoded from measurement.json files
+	_ "github.com/relab/hotstuff/internal/proto/orchestrationpb"
+	_ "github.com/relab/hotstuff/metrics/types"
 )
 
 var (


### PR DESCRIPTION
These imports were accidentally removed by me in 6e9b62f; added a comment to explain why they are needed.

Fixes #280

