### PR TITLE
chore: remove outdated TODO comment in VerifyQuorumCert

### DIFF
--- a/security/cert/auth.go
+++ b/security/cert/auth.go
@@ -119,7 +119,7 @@ func (c *Authority) VerifyQuorumCert(qc hotstuff.QuorumCert) error {
 		return nil
 	}
 
-	// TODO: FIX BUG - qcSignature can be nil when a leader is byzantine.
+	// Check for nil signature - can occur when leader is byzantine
 	qcSignature := qc.Signature()
 	if qcSignature == nil {
 		return fmt.Errorf("quorum certificate has nil signature (view=%d)", qc.View())


### PR DESCRIPTION
The TODO was marked as 'FIX BUG' but the bug has already been fixed. The code correctly checks for nil signature and returns an error. Changed to a descriptive comment explaining why the check exists.